### PR TITLE
feat: support both CPU and GPU proving

### DIFF
--- a/crates/node/src/serial.rs
+++ b/crates/node/src/serial.rs
@@ -12,7 +12,7 @@ use alloy_signer_local::PrivateKeySigner;
 use anyhow::{Context, Result};
 use chrono::{self, DateTime};
 use nvml_wrapper::Nvml;
-use sp1_sdk::{EnvProver, ProverClient, SP1ProofMode, SP1Stdin};
+use sp1_sdk::{EnvProver, SP1ProofMode, SP1Stdin};
 use spn_artifacts::{parse_artifact_id_from_url, Artifact};
 use spn_network_types::{
     prover_network_client::ProverNetworkClient, BidRequest, BidRequestBody, ExecutionStatus,


### PR DESCRIPTION
CPU example:

```sh
███████╗██╗   ██╗ ██████╗ ██████╗██╗███╗   ██╗ ██████╗████████╗
██╔════╝██║   ██║██╔════╝██╔════╝██║████╗  ██║██╔════╝╚══██╔══╝
███████╗██║   ██║██║     ██║     ██║██╔██╗ ██║██║        ██║   
╚════██║██║   ██║██║     ██║     ██║██║╚██╗██║██║        ██║   
███████║╚██████╔╝╚██████╗╚██████╗██║██║ ╚████║╚██████╗   ██║   
╚══════╝ ╚═════╝  ╚═════╝ ╚═════╝╚═╝╚═╝  ╚═══╝ ╚═════╝   ╚═╝   

Welcome to the Succinct Prover Node CLI! You're about to start your proving journey.

Fire up your machine and join a global network of provers where your compute helps prove the world's software. 

Learn more: https://docs.succinct.xyz

  2025-05-12T19:18:12.229358Z DEBUG  failed to execute nvidia-smi at nvidia-smi: No such file or directory (os error 2)

  2025-05-12T19:18:12.229644Z DEBUG  failed to execute nvidia-smi at /usr/bin/nvidia-smi: No such file or directory (os error 2)

  2025-05-12T19:18:12.229705Z DEBUG  failed to execute nvidia-smi at /usr/local/bin/nvidia-smi: No such file or directory (os error 2)

  2025-05-12T19:18:12.229735Z DEBUG  no working nvidia-smi found in any standard location

  2025-05-12T19:18:12.229743Z  INFO  no CUDA support detected, using CPU prover

  2025-05-12T19:18:31.697297Z  INFO  Starting Node on Succinct Network..., wallet: 0xCe0cB82A21C929B5070067BDa715E169eb10CABb, rpc: https://rpc-production.succinct.xyz, throughput: 1, bid_amount: 1

  2025-05-12T19:18:31.697751Z  INFO  [SerialMonitor] Checking node metrics..., fulfilled: 0, total_cycles: 0.00M, total_proving_time: 0s, throughput: 0 MHz

  2025-05-12T19:18:31.766920Z  INFO  [SerialProver] Fetched owner., owner: 4920765c3efaf6bb6275a8a42422dfc54c36f6ae
```