### PR TITLE
Use makeAddr for OWNER and AUCTIONEER in SuccinctVAppTest setup

### DIFF
--- a/contracts/test/SuccinctVApp.t.sol
+++ b/contracts/test/SuccinctVApp.t.sol
@@ -90,13 +90,8 @@ contract SuccinctVAppTest is Test, FixtureLoader {
         GENESIS_STATE_ROOT = fixture.oldRoot;
 
         // Create owner
-
-        // TODO: Fix these
-        // OWNER = makeAddr("OWNER");
-        // AUCTIONEER = makeAddr("AUCTIONEER");
-
-        OWNER = address(this);
-        AUCTIONEER = address(this);
+        OWNER = makeAddr("OWNER");
+        AUCTIONEER = makeAddr("AUCTIONEER");
         DISPENSER = makeAddr("DISPENSER");
         ALICE = makeAddr("ALICE");
         BOB = makeAddr("BOB");


### PR DESCRIPTION
Replaced the previous assignment of OWNER and AUCTIONEER with makeAddr("OWNER") and makeAddr("AUCTIONEER") in the setUp function of SuccinctVAppTest. This ensures consistent address generation for test accounts, matching the approach used for other test addresses in the suite. No other logic or structure was changed.