### PR TITLE
chore(contracts): remove duplicate IERC20 import

### DIFF
--- a/contracts/src/SuccinctStaking.sol
+++ b/contracts/src/SuccinctStaking.sol
@@ -8,7 +8,6 @@ import {IIntermediateSuccinct} from "./interfaces/IIntermediateSuccinct.sol";
 import {IProver} from "./interfaces/IProver.sol";
 import {Initializable} from "../lib/openzeppelin-contracts/contracts/proxy/utils/Initializable.sol";
 import {Ownable} from "../lib/openzeppelin-contracts/contracts/access/Ownable.sol";
-import {IERC20} from "../lib/openzeppelin-contracts/contracts/interfaces/IERC20.sol";
 import {IERC20Permit} from
     "../lib/openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Permit.sol";
 import {IERC4626} from "../lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";


### PR DESCRIPTION
This PR cleans up the imports in `SuccinctStaking.sol` by:

- Removing the duplicate `IERC20` import from `contracts/interfaces`.
- Consolidating on the single `IERC20` import under `token/ERC20/IERC20.sol`.

No functionality changes—just import housekeeping and linter green-lights.