### PR TITLE
fix: add timeout to artifacts reqwest client

### DIFF
--- a/crates/network/artifacts/src/lib.rs
+++ b/crates/network/artifacts/src/lib.rs
@@ -433,7 +433,14 @@ async fn download_s3_file(
 
 async fn download_https_file(uri: &str) -> Result<Bytes> {
     let client = reqwest::Client::new();
-    let res = client.get(uri).send().await.context("Failed to GET HTTPS URL")?;
+    let res = client
+        .get(uri)
+        .connect_timeout(Duration::from_secs(10))
+        .read_timeout(Duration::from_secs(30))
+        .timeout(Duration::from_secs(60))
+        .send()
+        .await
+        .context("Failed to GET HTTPS URL")?;
     if !res.status().is_success() {
         return Err(anyhow!("Failed to download from HTTPS URL {uri}: status {}", res.status()));
     }

--- a/crates/network/artifacts/src/lib.rs
+++ b/crates/network/artifacts/src/lib.rs
@@ -435,8 +435,6 @@ async fn download_https_file(uri: &str) -> Result<Bytes> {
     let client = reqwest::Client::new();
     let res = client
         .get(uri)
-        .connect_timeout(Duration::from_secs(10))
-        .read_timeout(Duration::from_secs(30))
         .timeout(Duration::from_secs(60))
         .send()
         .await


### PR DESCRIPTION
Add a reasonable timeout to reqwest GET to prevent artifact download from taking an absurdly long time.