### PR TITLE
fix(deps): consolidate SP1 versions to v5.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2558,20 +2558,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
-name = "downloader"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac1e888d6830712d565b2f3a974be3200be9296bc1b03db8251a4cbf18a4a34"
-dependencies = [
- "digest 0.10.7",
- "futures",
- "rand 0.8.5",
- "reqwest",
- "thiserror 1.0.69",
- "tokio",
-]
-
-[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5485,6 +5471,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.10",
@@ -6283,9 +6270,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "5.2.3"
+version = "5.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7bcc9e463a19749f6080f69ee6410aadda0576115d60bed68d2ebc2d8af3fe4"
+checksum = "c6c620b00f468a4eeb6050d5641d971b35aa623d2142ecb55d02fd64840c5f02"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -6297,9 +6284,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "5.2.3"
+version = "5.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb8bc70057a88164e479e367e2f83f7e7fba52d66acfbeef3b2174dc98c3627"
+checksum = "ca2363566d0d4213d0ffd93cfcc1a5e413e2af8682213d3e65b90ac0af5623e3"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -6336,9 +6323,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "5.2.3"
+version = "5.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe446bea36feb189af83cda6ea5420150e877764e2ed4ab4cb2ee5cd3e20355c"
+checksum = "1bd3ff75c100e24b89a7b513e082ec3e040c4c9f1cd779b6ba475c5bdc1aa7ad"
 dependencies = [
  "bincode",
  "cbindgen",
@@ -6392,9 +6379,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-cuda"
-version = "5.2.3"
+version = "5.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae79f89725c6e21dadb62be31a1c218292f5489559a848faf533419c722a3b3b"
+checksum = "e7d3b98d9dd20856176aa7048e2da05d0c3e497f500ea8590292ffbd25002ec1"
 dependencies = [
  "bincode",
  "ctrlc",
@@ -6409,9 +6396,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "5.2.3"
+version = "5.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a7ce14c504360349f3eda564a0c9de286c35e1dfbcc979921a3384db02ae82"
+checksum = "b7a5dc6007e0c1f35afe334e45531e17b8b347fdf73f6e7786ef5c1bc2218e30"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -6431,9 +6418,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "5.2.3"
+version = "5.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1144840e0b75e988f3b8d24ffd015bc5fd76599f7864bfd994f3eaf2eb261a"
+checksum = "83a1ed8d5acbb6cea056401791e79ca3cba7c7d5e17d0d44cd60e117f16b11ca"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -6441,9 +6428,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "5.2.3"
+version = "5.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1a9935d58cb1dcd757a1b10d727090f5b718f1f03b512d48f0c1952e6ead00"
+checksum = "b73b8ff343f2405d5935440e56b7aba5cee6d87303f0051974cbd6f5de502f57"
 dependencies = [
  "bincode",
  "elliptic-curve 0.13.8",
@@ -6453,9 +6440,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "5.2.3"
+version = "5.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7d2a6187e394c30097ea7a975a4832f172918690dc89a979f0fad67422d3a8b"
+checksum = "7e69a03098f827102c54c31a5e57280eb45b2c085de433b3f702e4f9e3ec1641"
 dependencies = [
  "bincode",
  "blake3",
@@ -6473,15 +6460,14 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "5.2.3"
+version = "5.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc62e3139fdb1671067987f78ca85a24ea34dbc2f61dbbe3f92b9739e7aa2b9"
+checksum = "b66f439f716cfc44c38d2aea975f1c4a9ed2cc40074ca7e4df8a37a3ff3795eb"
 dependencies = [
  "anyhow",
  "bincode",
  "clap",
  "dirs",
- "downloader",
  "enum-map",
  "eyre",
  "hashbrown 0.14.5",
@@ -6498,6 +6484,7 @@ dependencies = [
  "p3-symmetric",
  "p3-util",
  "rayon",
+ "reqwest",
  "serde",
  "serde_json",
  "serial_test",
@@ -6519,9 +6506,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "5.2.3"
+version = "5.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f16af7722bb0f7adabbfc0e60b7fe71ca546959d251c450afb79daaa589c56"
+checksum = "9c4a3739e84f154becfc7d2a57d23c825ac83313feec64569b86090395c33fab"
 dependencies = [
  "hashbrown 0.14.5",
  "itertools 0.13.0",
@@ -6554,9 +6541,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "5.2.3"
+version = "5.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c83564beb23361e0b93d64f3b8d4a503eac8ced246648f727d44b0827165014"
+checksum = "06aa784cfdc5c979da22ad6c36fe393e9005b6b57702fa9bdd041f112ead5ec5"
 dependencies = [
  "backtrace",
  "itertools 0.13.0",
@@ -6576,9 +6563,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-core"
-version = "5.2.3"
+version = "5.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c209fa6e384ff56ea7761ccc65426da08516d72ae55b6d8e4021b58bd4022f8"
+checksum = "5be0db07b18f95f4e04f63f7f12a6547efd10601e2ce180aaf7868aa1bd98257"
 dependencies = [
  "backtrace",
  "cbindgen",
@@ -6619,9 +6606,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-derive"
-version = "5.2.3"
+version = "5.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8ca2e82fea312a406f4ad4cba1a11812da4cea806607c56ec1670fd55b2ea6"
+checksum = "1b190465c0c0377f3cacfac2d0ac8a630adf8e1bfac8416be593753bfa4f668e"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -6629,9 +6616,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "5.2.3"
+version = "5.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e146d24ce91c08e36b270a73de9817b9847e759a3d66923b009c67f24a3b9b2"
+checksum = "933ef703fb1c7a25e987a76ad705e60bb53730469766363b771baf3082a50fa0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6655,9 +6642,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "5.2.3"
+version = "5.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9655067dcadba91f01491729cc78a60ad3a5ffaaf9adab817502f729ddb3761"
+checksum = "ed3ae8bc52d12e8fbfdb10c4c8ce7651af04b63d390c152e6ce43d7744bbaf6f"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -6708,9 +6695,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-stark"
-version = "5.2.3"
+version = "5.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40477690a0bb6d7102322947407439a8f1d05aecd535f0081db05e9a31f808f2"
+checksum = "0e99d1cc89ba28fc95736afb1e6ad22b9eb689e95a1dbb29cf0e9d1fa4fc2a5c"
 dependencies = [
  "arrayref",
  "hashbrown 0.14.5",
@@ -6742,9 +6729,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "5.2.3"
+version = "5.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f95bd323fde5d19116873b29e5f8e20da371466d70185732bbfd3511ca0fd31"
+checksum = "1904bbb3c2d16a7a11db32900f468149bc66253825e222f2db76f64fb8ffd1ab"
 dependencies = [
  "blake3",
  "cfg-if",
@@ -6757,9 +6744,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "5.2.3"
+version = "5.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e767ed85f89b1c8d84188c2cc035833079529bb0ddd8f7bd252de91ce562acc7"
+checksum = "d6247de4d980d1f3311fa877cc5d2d3b7e111258878c8196a8bb9728aec98c8c"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.16",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,11 +38,11 @@ spn-network-types = { path = "crates/types/network" }
 spn-vapp-core = { path = "crates/vapp" }
 
 # sp1
-sp1-sdk = "5.2.3"
-sp1-prover = "5.2.3"
-sp1-verifier = "5.2.3"
-sp1-zkvm = "5.2.3"
-sp1-build = "5.2.3"
+sp1-sdk = "5.2.4"
+sp1-prover = "5.2.4"
+sp1-verifier = "5.2.4"
+sp1-zkvm = "5.2.4"
+sp1-build = "5.2.4"
 
 # aws
 aws-config = "1.5.3"

--- a/programs/vapp/aggregation/Cargo.toml
+++ b/programs/vapp/aggregation/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 spn-vapp-core = { workspace = true }
 alloy-sol-types = { workspace = true }
 sha2 = { workspace = true }
-sp1-zkvm = { version = "5.1.0", features = ["verify"] }
+sp1-zkvm = { workspace = true, features = ["verify"] }
 
 [build-dependencies]
 sp1-sdk = { workspace = true, default-features = false }

--- a/programs/vapp/stf/Cargo.toml
+++ b/programs/vapp/stf/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 spn-vapp-core = { workspace = true }
 alloy-primitives = { workspace = true, features = ["k256", "tiny-keccak"] }
 alloy-sol-types = { workspace = true }
-sp1-zkvm = { version = "5.1.0", features = ["verify"] }
+sp1-zkvm = { workspace = true, features = ["verify"] }

--- a/x.sh
+++ b/x.sh
@@ -28,7 +28,7 @@ done
 # Build the STF program.
 echo "Building STF program..."
 cd programs/vapp/stf
-cargo prove build --elf-name spn-vapp-stf $USE_DOCKER --tag v5.1.0 --output-directory ../../../elf
+cargo prove build --elf-name spn-vapp-stf $USE_DOCKER --tag v5.2.4 --output-directory ../../../elf
 cd ../../..
 echo "Done!"
 echo ""
@@ -36,7 +36,7 @@ echo ""
 # Build the aggregation program.
 echo "Building aggregation program..."
 cd programs/vapp/aggregation
-cargo prove build --elf-name spn-vapp-aggregation $USE_DOCKER --tag v5.1.0 --output-directory ../../../elf
+cargo prove build --elf-name spn-vapp-aggregation $USE_DOCKER --tag v5.2.4 --output-directory ../../../elf
 cd ../../..
 echo "Done!"
 echo ""
@@ -44,7 +44,7 @@ echo ""
 # Build the fibonacci example program.
 echo "Building fibonacci program..."
 cd programs/examples/fibonacci
-cargo prove build --elf-name spn-fibonacci-program $USE_DOCKER --tag v5.1.0 --output-directory ../../../elf
+cargo prove build --elf-name spn-fibonacci-program $USE_DOCKER --tag v5.2.4 --output-directory ../../../elf
 cd ../../..
 echo "Done!"
 echo ""


### PR DESCRIPTION
Consolidate all SP1 dependency versions to v5.2.4 (latest v5.x). The workspace had 5.2.3 in root Cargo.toml and 5.1.0 hardcoded in vapp programs, while `action.yml` setup always pulling the latest (v5.2.4).