### PR TITLE
feat: v6.1.0 upgrade

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -58,4 +58,4 @@ runs:
     - name: "Install SP1 toolchain"
       shell: bash
       run: |
-        sp1up --version v6.0.2
+        sp1up --version v6.1.0

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -39,14 +39,14 @@ runs:
           ~/.cargo/git/db/
           target/
           ~/.rustup/
-        key: rust-1.88.0-${{ hashFiles('**/Cargo.toml') }}
-        restore-keys: rust-1.88.0-
+        key: rust-1.91.0-${{ hashFiles('**/Cargo.toml') }}
+        restore-keys: rust-1.91.0-
 
     - name: Setup toolchain
       id: rustc-toolchain
       shell: bash
       run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.88.0 -y
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.91.0 -y
         rustup install nightly
 
     - name: "Install sp1up"
@@ -58,4 +58,4 @@ runs:
     - name: "Install SP1 toolchain"
       shell: bash
       run: |
-        sp1up --version v5.2.4
+        sp1up --version v6.0.2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -86,11 +86,11 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          toolchain: 1.88.0
+          toolchain: 1.91.0
           args: --release
         env:
           RUST_BACKTRACE: 1
-          RUSTUP_TOOLCHAIN: 1.88.0
+          RUSTUP_TOOLCHAIN: 1.91.0
 
   cargo-lint:
     name: Cargo Lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,12 @@ jobs:
           sudo docker system prune -af
           df -h
 
-      - name: Install protobuf compiler
+      - name: Patch SP1 Docker image with protobuf includes
         run: |
-          sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
+          docker pull ghcr.io/succinctlabs/sp1:v6.0.2
+          echo 'FROM ghcr.io/succinctlabs/sp1:v6.0.2
+          RUN apt-get update && apt-get install -y --no-install-recommends libprotobuf-dev && rm -rf /var/lib/apt/lists/*' \
+            | docker build -t ghcr.io/succinctlabs/sp1:v6.0.2 -
 
       - name: Build RISC-V ELFs
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,10 @@ jobs:
 
       - name: Patch SP1 Docker image with protobuf includes
         run: |
-          docker pull ghcr.io/succinctlabs/sp1:v6.0.2
-          echo 'FROM ghcr.io/succinctlabs/sp1:v6.0.2
+          docker pull ghcr.io/succinctlabs/sp1:v6.1.0
+          echo 'FROM ghcr.io/succinctlabs/sp1:v6.1.0
           RUN apt-get update && apt-get install -y --no-install-recommends libprotobuf-dev && rm -rf /var/lib/apt/lists/*' \
-            | docker build -t ghcr.io/succinctlabs/sp1:v6.0.2 -
+            | docker build -t ghcr.io/succinctlabs/sp1:v6.1.0 -
 
       - name: Build RISC-V ELFs
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,13 +28,6 @@ jobs:
           sudo docker system prune -af
           df -h
 
-      - name: Patch SP1 Docker image with protobuf includes
-        run: |
-          docker pull ghcr.io/succinctlabs/sp1:v6.1.0
-          echo 'FROM ghcr.io/succinctlabs/sp1:v6.1.0
-          RUN apt-get update && apt-get install -y --no-install-recommends libprotobuf-dev && rm -rf /var/lib/apt/lists/*' \
-            | docker build -t ghcr.io/succinctlabs/sp1:v6.1.0 -
-
       - name: Build RISC-V ELFs
         run: |
           ./x.sh --docker

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4583,13 +4583,14 @@ dependencies = [
 [[package]]
 name = "p256"
 version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-p256-13.2-sp1-6.0.0#64d5ce2a3d956b3036cb6381b49777531df047ba"
 dependencies = [
  "ecdsa 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "elliptic-curve 0.13.8",
+ "hex",
  "primeorder",
  "sha2",
+ "sp1-lib",
 ]
 
 [[package]]
@@ -5099,9 +5100,8 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+version = "0.13.1"
+source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-p256-13.2-sp1-6.0.0#64d5ce2a3d956b3036cb6381b49777531df047ba"
 dependencies = [
  "elliptic-curve 0.13.8",
 ]
@@ -6302,8 +6302,7 @@ dependencies = [
 [[package]]
 name = "sha3"
 version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha3-0.10.8-sp1-6.0.0#0a16ae7acd5cd5fbb432d884bd4aae2764a18cf7"
 dependencies = [
  "digest 0.10.7",
  "keccak",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ checksum = "19a9cc9d81ace3da457883b0bdf76776e55f1b84219a9e9d55c27ad308548d3f"
 dependencies = [
  "alloy-primitives",
  "num_enum 0.7.3",
- "strum 0.27.1",
+ "strum",
 ]
 
 [[package]]
@@ -502,24 +502,6 @@ dependencies = [
  "elliptic-curve 0.13.8",
  "k256",
  "thiserror 2.0.12",
-]
-
-[[package]]
-name = "alloy-signer-aws"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6be3d371299b62eac5aa459fa58e8d1c761aabdc637573ae258ab744457fcc88"
-dependencies = [
- "alloy-consensus",
- "alloy-network",
- "alloy-primitives",
- "alloy-signer",
- "async-trait",
- "aws-sdk-kms",
- "k256",
- "spki 0.7.3",
- "thiserror 2.0.12",
- "tracing",
 ]
 
 [[package]]
@@ -962,6 +944,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-scoped"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4042078ea593edffc452eef14e99fdb2b120caa4ad9618bcdeabc4a023b98740"
+dependencies = [
+ "futures",
+ "pin-project",
+ "tokio",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,6 +985,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -1105,28 +1107,6 @@ dependencies = [
  "pin-project-lite",
  "tracing",
  "uuid",
-]
-
-[[package]]
-name = "aws-sdk-kms"
-version = "1.81.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04729ca4652a5363689c07f825fea6649b1967820caafea5122a197e47ee83cb"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "regex-lite",
- "tracing",
 ]
 
 [[package]]
@@ -1567,6 +1547,12 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -1901,25 +1887,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cbindgen"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fce8dd7fcfcbf3a0a87d8f515194b49d6135acab73e18bd380d1d93bb1a15eb"
-dependencies = [
- "clap",
- "heck 0.4.1",
- "indexmap 2.9.0",
- "log",
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "syn 2.0.101",
- "tempfile",
- "toml",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1941,9 +1908,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -2044,6 +2011,12 @@ dependencies = [
  "unicode-width 0.2.0",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "const-default"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b396d1f76d455557e1218ec8066ae14bba60b4b36ecd55577ba979f5db7ecaa"
 
 [[package]]
 name = "const-hex"
@@ -2170,6 +2143,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2193,6 +2185,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2224,7 +2225,8 @@ dependencies = [
 [[package]]
 name = "crypto-bigint"
 version = "0.5.5"
-source = "git+https://github.com/sp1-patches/RustCrypto-bigint?tag=patch-0.5.5-sp1-4.0.0#d421029772fb604022defd4cae5fffb269ad5155"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array 0.14.7",
  "rand_core 0.6.4",
@@ -2240,16 +2242,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array 0.14.7",
  "typenum",
-]
-
-[[package]]
-name = "ctrlc"
-version = "3.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f93780a459b7d656ef7f071fe699c4d3d2cb201c4b24d085b6ddc505276e73"
-dependencies = [
- "nix",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2416,6 +2408,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "deepsize2"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b5184084af9beed35eecbf4c36baf6e26b9dc47b61b74e02f930c72a58e71b"
+dependencies = [
+ "deepsize_derive2",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "deepsize_derive2"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0f8817865cacf3b93b943ca06b0fc5fd8e99eabfdb7ea5d296efcbc4afc4f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "der"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2455,6 +2468,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive-where"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2578,6 +2602,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dynasm"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7d4c414c94bc830797115b8e5f434d58e7e80cb42ba88508c14bc6ea270625"
+dependencies = [
+ "bitflags 2.9.1",
+ "byteorder",
+ "lazy_static",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "dynasmrt"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "602f7458a3859195fb840e6e0cce5f4330dd9dfbfece0edaf31fe427af346f55"
+dependencies = [
+ "byteorder",
+ "dynasm",
+ "fnv",
+ "memmap2",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2592,12 +2643,26 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.16.9"
-source = "git+https://github.com/sp1-patches/signatures.git?tag=patch-16.9-sp1-4.1.0#1880299a48fe7ef249edaa616fd411239fb5daf1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der 0.7.10",
  "digest 0.10.7",
  "elliptic-curve 0.13.8",
- "rfc6979 0.4.0",
+ "rfc6979 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signature 2.2.0",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "git+https://github.com/sp1-patches/signatures?tag=sp1-skip-verify-on-recovery#1880299a48fe7ef249edaa616fd411239fb5daf1"
+dependencies = [
+ "der 0.7.10",
+ "digest 0.10.7",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0 (git+https://github.com/sp1-patches/signatures?tag=sp1-skip-verify-on-recovery)",
  "serdect",
  "signature 2.2.0",
  "spki 0.7.3",
@@ -2670,6 +2735,18 @@ dependencies = [
  "serdect",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "embedded-alloc"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f2de9133f68db0d4627ad69db767726c99ff8585272716708227008d3f1bddd"
+dependencies = [
+ "const-default",
+ "critical-section",
+ "linked_list_allocator",
+ "rlsf",
 ]
 
 [[package]]
@@ -3783,10 +3860,10 @@ dependencies = [
 [[package]]
 name = "k256"
 version = "0.13.4"
-source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-k256-13.4-sp1-5.0.0#f7d8998e05d8cbcbd8e543eba1030a7385011fa8"
+source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-k256-13.4-sp1-6.0.0#0efe186cee5930a0d23501651c226bd81fcc2c15"
 dependencies = [
  "cfg-if",
- "ecdsa 0.16.9",
+ "ecdsa 0.16.9 (git+https://github.com/sp1-patches/signatures?tag=sp1-skip-verify-on-recovery)",
  "elliptic-curve 0.13.8",
  "hex",
  "once_cell",
@@ -3882,6 +3959,12 @@ dependencies = [
  "bitflags 2.9.1",
  "libc",
 ]
+
+[[package]]
+name = "linked_list_allocator"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afa463f5405ee81cdb9cc2baf37e08ec7e4c8209442b5d72c04cfb2cd6e6286"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3991,6 +4074,24 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memfd"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+dependencies = [
+ "rustix 1.0.7",
+]
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memuse"
@@ -4108,6 +4209,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "mti"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9563a7d5556636e74bbd8773241fbcbc5c89b9f6bfdc97b29b56e740c2c74b9"
+dependencies = [
+ "typeid_prefix",
+ "typeid_suffix",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4129,24 +4240,6 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
-
-[[package]]
-name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags 2.9.1",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
-
-[[package]]
-name = "nohash-hasher"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -4451,6 +4544,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b69a91d4893e713e06f724597ad630f1fa76057a5e1026c0ca67054a9032a76"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4476,31 +4583,31 @@ dependencies = [
 [[package]]
 name = "p256"
 version = "0.13.2"
-source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-p256-13.2-sp1-5.0.0#10cca2ef98bebbad35e2475849433fc3e75e27d9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
- "ecdsa 0.16.9",
+ "ecdsa 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "elliptic-curve 0.13.8",
- "hex",
  "primeorder",
  "sha2",
- "sp1-lib",
 ]
 
 [[package]]
 name = "p3-air"
-version = "0.2.3-succinct"
+version = "0.3.2-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05a97452c4b1cfa8626e69181d901fc8231d99ff7d87e9701a2e6b934606615"
+checksum = "d275c27bb81483d669709d7244ce333b51f9743af2474cdc09ba1509f5c290db"
 dependencies = [
  "p3-field",
  "p3-matrix",
+ "serde",
 ]
 
 [[package]]
 name = "p3-baby-bear"
-version = "0.2.3-succinct"
+version = "0.3.2-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7521838ecab2ddf4f7bc4ceebad06ec02414729598485c1ada516c39900820e8"
+checksum = "95a083928c9055f2171e3cb0bb4767969e4955473e71ba61affe46d7a3c98a89"
 dependencies = [
  "num-bigint 0.4.6",
  "p3-field",
@@ -4513,9 +4620,9 @@ dependencies = [
 
 [[package]]
 name = "p3-bn254-fr"
-version = "0.2.3-succinct"
+version = "0.3.2-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0dd4d095d254783098bd09fc5fdf33fd781a1be54608ab93cb3ed4bd723da54"
+checksum = "9abf208fbfe540d6e2a6caaa2a9a345b1c8cb23ffdcdfcc6987244525d4fc821"
 dependencies = [
  "ff 0.13.1",
  "num-bigint 0.4.6",
@@ -4528,9 +4635,9 @@ dependencies = [
 
 [[package]]
 name = "p3-challenger"
-version = "0.2.3-succinct"
+version = "0.3.2-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5d18c223b7e0177f4ac91070fa3f6cc557d5ee3b279869924c3102fb1b20910"
+checksum = "42b725b453bbb35117a1abf0ddfd900b0676063d6e4231e0fa6bb0d76018d8ad"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -4542,9 +4649,9 @@ dependencies = [
 
 [[package]]
 name = "p3-commit"
-version = "0.2.3-succinct"
+version = "0.3.2-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b38fe979d53d4f1d64158c40b3cd9ea1bd6b7bc8f085e489165c542ef914ae28"
+checksum = "518695b56f450f9223bdd8994dda87916b97ebf1d1c03c956807e78522fdb333"
 dependencies = [
  "itertools 0.12.1",
  "p3-challenger",
@@ -4556,9 +4663,9 @@ dependencies = [
 
 [[package]]
 name = "p3-dft"
-version = "0.2.3-succinct"
+version = "0.3.2-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46414daedd796f1eefcdc1811c0484e4bced5729486b6eaba9521c572c76761a"
+checksum = "56a1f81101bff744b7ebba7f4497e917a2c6716d6e62736e4a56e555a2d98cb7"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -4569,9 +4676,9 @@ dependencies = [
 
 [[package]]
 name = "p3-field"
-version = "0.2.3-succinct"
+version = "0.3.2-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48948a0516b349e9d1cdb95e7236a6ee010c44e68c5cc78b4b92bf1c4022a0d9"
+checksum = "36459d4acb03d08097d713f336c7393990bb489ab19920d4f68658c7a5c10968"
 dependencies = [
  "itertools 0.12.1",
  "num-bigint 0.4.6",
@@ -4583,9 +4690,9 @@ dependencies = [
 
 [[package]]
 name = "p3-fri"
-version = "0.2.3-succinct"
+version = "0.3.2-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c274dab2dcd060cdea9ab3f8f7129f5fa5f08917d6092dc2b297a31d883aa0"
+checksum = "6e2529a174a04189cfe705d756fb0e33d3c8fb06b167b521ddb877c78407f12a"
 dependencies = [
  "itertools 0.12.1",
  "p3-challenger",
@@ -4602,9 +4709,9 @@ dependencies = [
 
 [[package]]
 name = "p3-interpolation"
-version = "0.2.3-succinct"
+version = "0.3.2-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed8de7333abb0ad0a17bb78726a43749cc7fcab4763f296894e8b2933841d4d8"
+checksum = "6662049877c802155cdb4863db59899469fc3565d22d9047e1bd22d6b71f28e5"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -4613,9 +4720,9 @@ dependencies = [
 
 [[package]]
 name = "p3-keccak-air"
-version = "0.2.3-succinct"
+version = "0.3.2-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c7ec21317c455d39588428e4ec85b96d663ff171ddf102a10e2ca54c942dea"
+checksum = "169c96f8f0aaa9042872fdb6bbae0477fd1363b87c23877dbb2ec7fb46f8fcfa"
 dependencies = [
  "p3-air",
  "p3-field",
@@ -4626,10 +4733,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "p3-matrix"
-version = "0.2.3-succinct"
+name = "p3-koala-bear"
+version = "0.3.2-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4de3f373589477cb735ea58e125898ed20935e03664b4614c7fac258b3c42f"
+checksum = "eb1f52bcb6be38bdc8fa6b38b3434d4eedd511f361d4249fd798c6a5ef817b40"
+dependencies = [
+ "num-bigint 0.4.6",
+ "p3-field",
+ "p3-mds",
+ "p3-poseidon2",
+ "p3-symmetric",
+ "rand 0.8.5",
+ "serde",
+]
+
+[[package]]
+name = "p3-matrix"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5583e9cd136a4095a25c41a9edfdcce2dfae58ef01639317813bdbbd5b55c583"
 dependencies = [
  "itertools 0.12.1",
  "p3-field",
@@ -4642,18 +4764,18 @@ dependencies = [
 
 [[package]]
 name = "p3-maybe-rayon"
-version = "0.2.3-succinct"
+version = "0.3.2-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3968ad1160310296eb04f91a5f4edfa38fe1d6b2b8cd6b5c64e6f9b7370979e"
+checksum = "e524d47a49fb4265611303339c4ef970d892817b006cc330dad18afb91e411b1"
 dependencies = [
  "rayon",
 ]
 
 [[package]]
 name = "p3-mds"
-version = "0.2.3-succinct"
+version = "0.3.2-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2356b1ed0add6d5dfbf7a338ce534a6fde827374394a52cec16a0840af6e97c9"
+checksum = "4f6cb8edcb276033d43769a3725570c340d2ed6f35c3cca4cddeee07718fa376"
 dependencies = [
  "itertools 0.12.1",
  "p3-dft",
@@ -4666,9 +4788,9 @@ dependencies = [
 
 [[package]]
 name = "p3-merkle-tree"
-version = "0.2.3-succinct"
+version = "0.3.2-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f159e073afbee02c00d22390bf26ebb9ce03bbcd3e6dcd13c6a7a3811ab39608"
+checksum = "a5e8bc3c224fc70d22f9556393e1482b52539e11c7b82ac6933c436fd82738f4"
 dependencies = [
  "itertools 0.12.1",
  "p3-commit",
@@ -4683,9 +4805,9 @@ dependencies = [
 
 [[package]]
 name = "p3-poseidon2"
-version = "0.2.3-succinct"
+version = "0.3.2-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da1eec7e1b6900581bedd95e76e1ef4975608dd55be9872c9d257a8a9651c3a"
+checksum = "5a26197df2097b98ab7038d59a01e1fe1a0f545e7e04aa9436b2454b1836654f"
 dependencies = [
  "gcd",
  "p3-field",
@@ -4697,9 +4819,9 @@ dependencies = [
 
 [[package]]
 name = "p3-symmetric"
-version = "0.2.3-succinct"
+version = "0.3.2-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb439bea1d822623b41ff4b51e3309e80d13cadf8b86d16ffd5e6efb9fdc360"
+checksum = "3a1d3b5202096bca57cde912fbbb9cbaedaf5ac7c42a924c7166b98709d64d21"
 dependencies = [
  "itertools 0.12.1",
  "p3-field",
@@ -4708,9 +4830,9 @@ dependencies = [
 
 [[package]]
 name = "p3-uni-stark"
-version = "0.2.3-succinct"
+version = "0.3.2-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a86f29c32bf46fa4acb6547d2065a711e146d4faca388b56d75718c60a0097d"
+checksum = "fef1cdb8285a7adb78df991852d3b66d3b25cf6ffc34f528505d1aee49bdb968"
 dependencies = [
  "itertools 0.12.1",
  "p3-air",
@@ -4727,9 +4849,9 @@ dependencies = [
 
 [[package]]
 name = "p3-util"
-version = "0.2.3-succinct"
+version = "0.3.2-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c2c2010678b9332b563eaa38364915b585c1a94b5ca61e2c7541c087ddda5c"
+checksum = "ec5f0388aa6d935ca3a17444086120f393f0b2f0816010b5ff95998c1c4095e3"
 dependencies = [
  "serde",
 ]
@@ -4840,12 +4962,6 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pathdiff"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pem-rfc7468"
@@ -4983,8 +5099,9 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.13.1"
-source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-p256-13.2-sp1-5.0.0#10cca2ef98bebbad35e2475849433fc3e75e27d9"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve 0.13.8",
 ]
@@ -5526,21 +5643,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest-middleware"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562ceb5a604d3f7c885a792d42c199fd8af239d0a51b2fa6a78aafa092452b04"
-dependencies = [
- "anyhow",
- "async-trait",
- "http 1.3.1",
- "reqwest",
- "serde",
- "thiserror 1.0.69",
- "tower-service",
-]
-
-[[package]]
 name = "rfc6979"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5554,7 +5656,17 @@ dependencies = [
 [[package]]
 name = "rfc6979"
 version = "0.4.0"
-source = "git+https://github.com/sp1-patches/signatures.git?tag=patch-16.9-sp1-4.1.0#1880299a48fe7ef249edaa616fd411239fb5daf1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "git+https://github.com/sp1-patches/signatures?tag=sp1-skip-verify-on-recovery#1880299a48fe7ef249edaa616fd411239fb5daf1"
 dependencies = [
  "hmac",
  "subtle",
@@ -5594,10 +5706,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "rrs-succinct"
-version = "0.1.0"
+name = "rlsf"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3372685893a9f67d18e98e792d690017287fd17379a83d798d958e517d380fa9"
+checksum = "1646a59a9734b8b7a0ac51689388a60fe1625d4b956348e9de07591a1478457a"
+dependencies = [
+ "cfg-if",
+ "const-default",
+ "libc",
+ "rustversion",
+ "svgbobdoc",
+]
+
+[[package]]
+name = "rrs-succinct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd079cd303257a4cb4e5aadfa79a7fe23f3c8301aa4740ccc3a99673485a352"
 dependencies = [
  "downcast-rs",
  "num_enum 0.5.11",
@@ -6020,6 +6145,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_arrays"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94a16b99c5ea4fe3daccd14853ad260ec00ea043b2708d1fd1da3106dcd8d9df"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6058,15 +6192,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
 dependencies = [
  "itoa",
- "serde",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
-dependencies = [
  "serde",
 ]
 
@@ -6159,9 +6284,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
-source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.10.8-sp1-4.0.0#1f224388fdede7cef649bce0d63876d1a9e3f515"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.10.8-sp1-6.0.0#75b15faa7ce44d25435d0a3209285455540f0b7f"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -6171,7 +6302,8 @@ dependencies = [
 [[package]]
 name = "sha3"
 version = "0.10.8"
-source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha3-0.10.8-sp1-4.0.0#8f6d303c0861ba7e5adcc36207c0f41fe5edaabc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.7",
  "keccak",
@@ -6232,12 +6364,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "size"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fed904c7fb2856d868b92464fc8fa597fce366edea1a9cbfaa8cb5fe080bd6d"
-
-[[package]]
 name = "sketches-ddsketch"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6250,6 +6376,442 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "slop-air"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "242539aba9e5424923d7bd629775570c7d10ec28584e96ea599575a51bedcde8"
+dependencies = [
+ "p3-air",
+]
+
+[[package]]
+name = "slop-algebra"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "691beea96fd18d4881f9ca1cb4e58194dac6366f24956a2fdae00c8ee382a0c9"
+dependencies = [
+ "itertools 0.14.0",
+ "p3-field",
+ "serde",
+]
+
+[[package]]
+name = "slop-alloc"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f58b7800cba9b31377f9353174d13fd8e39608b6f1d1531f0e92b8ce4af49ae0"
+dependencies = [
+ "serde",
+ "slop-algebra",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "slop-baby-bear"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "949e3c822532a87b4ad04f7280283c256621b0a83aee1b40cbd721df29df641d"
+dependencies = [
+ "lazy_static",
+ "p3-baby-bear",
+ "serde",
+ "slop-algebra",
+ "slop-challenger",
+ "slop-poseidon2",
+ "slop-symmetric",
+]
+
+[[package]]
+name = "slop-basefold"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58984f92091a668a006b6895487079d99209e599b02d636f061fe4ae26977fb5"
+dependencies = [
+ "derive-where",
+ "itertools 0.14.0",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-baby-bear",
+ "slop-bn254",
+ "slop-challenger",
+ "slop-koala-bear",
+ "slop-merkle-tree",
+ "slop-multilinear",
+ "slop-primitives",
+ "slop-tensor",
+ "slop-utils",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "slop-basefold-prover"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86eb8581b52f97860242fe5e8d6b49d2a37e1b38d4a647adf24acaa2965ee7d"
+dependencies = [
+ "derive-where",
+ "itertools 0.14.0",
+ "rand 0.8.5",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-baby-bear",
+ "slop-basefold",
+ "slop-bn254",
+ "slop-challenger",
+ "slop-commit",
+ "slop-dft",
+ "slop-fri",
+ "slop-futures",
+ "slop-koala-bear",
+ "slop-merkle-tree",
+ "slop-multilinear",
+ "slop-tensor",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "slop-bn254"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1852499c245f7f3dec23408b4930b3ea7570ae914b9c31f12950ac539d85ee"
+dependencies = [
+ "ff 0.13.1",
+ "p3-bn254-fr",
+ "serde",
+ "slop-algebra",
+ "slop-challenger",
+ "slop-poseidon2",
+ "slop-symmetric",
+ "zkhash",
+]
+
+[[package]]
+name = "slop-challenger"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4349af93602f3876a3eda948a74d9d16d774c401dfe25f41a45ffd84f230bc1"
+dependencies = [
+ "futures",
+ "p3-challenger",
+ "serde",
+ "slop-algebra",
+ "slop-symmetric",
+]
+
+[[package]]
+name = "slop-commit"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "584339690d20fb6b34b0dc957cbd267221ba2ab7b0c1292c118378f3498979c4"
+dependencies = [
+ "p3-commit",
+ "serde",
+ "slop-alloc",
+]
+
+[[package]]
+name = "slop-dft"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "148281e1611ca570d016a733aac2f3ec9867241cc800a96d15bc6ecfd010daf7"
+dependencies = [
+ "p3-dft",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-matrix",
+ "slop-tensor",
+]
+
+[[package]]
+name = "slop-fri"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0857a346ea28496ee56b1dcad192db8c7ff0455a18bfd67ce6513323b594b746"
+dependencies = [
+ "p3-fri",
+]
+
+[[package]]
+name = "slop-futures"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bbfea5447d243572da7aae8d5e57856229a97fb8bc6a42439d4c5f4de951ee0"
+dependencies = [
+ "crossbeam",
+ "futures",
+ "pin-project",
+ "rayon",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "slop-jagged"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc420430b93d38e9aae903bc4bc11c342f8d49d015cca26eeb36a6ea3f7a0f1f"
+dependencies = [
+ "derive-where",
+ "futures",
+ "itertools 0.14.0",
+ "num_cpus",
+ "rand 0.8.5",
+ "rayon",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-baby-bear",
+ "slop-basefold",
+ "slop-basefold-prover",
+ "slop-bn254",
+ "slop-challenger",
+ "slop-commit",
+ "slop-futures",
+ "slop-koala-bear",
+ "slop-merkle-tree",
+ "slop-multilinear",
+ "slop-stacked",
+ "slop-sumcheck",
+ "slop-symmetric",
+ "slop-tensor",
+ "slop-utils",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "slop-keccak-air"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "288abf40d9901f79e221ece87f11324826289bf5d694fde07dd785bdb4afda38"
+dependencies = [
+ "p3-keccak-air",
+]
+
+[[package]]
+name = "slop-koala-bear"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "574784c044d11cf9d8238dc18bce9b897bc34d0fb1daaceafd75ebb400084016"
+dependencies = [
+ "lazy_static",
+ "p3-koala-bear",
+ "serde",
+ "slop-algebra",
+ "slop-challenger",
+ "slop-poseidon2",
+ "slop-symmetric",
+]
+
+[[package]]
+name = "slop-matrix"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd1117c395388bd172826115ac4f9a7e09bf9c937ceafa82194132a058e27c0d"
+dependencies = [
+ "p3-matrix",
+]
+
+[[package]]
+name = "slop-maybe-rayon"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81316cfe721c3f47cd0af63002a8b6557c951ff9588fa7db0f4f3b99af091486"
+dependencies = [
+ "p3-maybe-rayon",
+]
+
+[[package]]
+name = "slop-merkle-tree"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e700652778c15320f6269362103b87a3787a7c9d70fb05d9742dbce66c46f764"
+dependencies = [
+ "derive-where",
+ "ff 0.13.1",
+ "itertools 0.14.0",
+ "p3-merkle-tree",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-baby-bear",
+ "slop-bn254",
+ "slop-challenger",
+ "slop-commit",
+ "slop-futures",
+ "slop-koala-bear",
+ "slop-matrix",
+ "slop-poseidon2",
+ "slop-symmetric",
+ "slop-tensor",
+ "thiserror 1.0.69",
+ "zkhash",
+]
+
+[[package]]
+name = "slop-multilinear"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6151db452ace0d960314f46c61a2b8d45e1fa4dfd5830447c67fc1e1e1e823b5"
+dependencies = [
+ "derive-where",
+ "futures",
+ "num_cpus",
+ "rand 0.8.5",
+ "rayon",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-challenger",
+ "slop-commit",
+ "slop-futures",
+ "slop-matrix",
+ "slop-tensor",
+]
+
+[[package]]
+name = "slop-poseidon2"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5af617970b63e8d7199204bc02996745b6c35c39f2b513a118c62c7b1a0b2f1b"
+dependencies = [
+ "p3-poseidon2",
+]
+
+[[package]]
+name = "slop-primitives"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58d82c53508f3ebff8acdabb5db2584f37686257a2549a17c977cf30cd9e24e6"
+dependencies = [
+ "slop-algebra",
+]
+
+[[package]]
+name = "slop-stacked"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a25c9fb9c908a2d10037934e2c299d30f98a2146f6ded87a7b529b05ddbfda27"
+dependencies = [
+ "derive-where",
+ "futures",
+ "itertools 0.14.0",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-basefold",
+ "slop-basefold-prover",
+ "slop-challenger",
+ "slop-commit",
+ "slop-futures",
+ "slop-merkle-tree",
+ "slop-multilinear",
+ "slop-tensor",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "slop-sumcheck"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c691f34c05e933777059a10804e00f77834b927abc2701f5f394e9c2b49c1c"
+dependencies = [
+ "futures",
+ "itertools 0.14.0",
+ "rayon",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-baby-bear",
+ "slop-challenger",
+ "slop-multilinear",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "slop-symmetric"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15acfa7f567ffa4f36de134492632a397c33fa6af2e48894e50978b52eeeb871"
+dependencies = [
+ "p3-symmetric",
+]
+
+[[package]]
+name = "slop-tensor"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1796e5ff7dcdcd2c15f423a27550a4688e25009bd5ca648d9593d66f243950d6"
+dependencies = [
+ "arrayvec",
+ "derive-where",
+ "itertools 0.14.0",
+ "rand 0.8.5",
+ "rayon",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-futures",
+ "slop-matrix",
+ "thiserror 1.0.69",
+ "transpose",
+]
+
+[[package]]
+name = "slop-uni-stark"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504f32330985e48a6aa9c9e0985641a4dc084d3843ff59075591b24b818f2a67"
+dependencies = [
+ "p3-uni-stark",
+]
+
+[[package]]
+name = "slop-utils"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba510663661800990c1207ddbf3a1e67a551f05d882a60197adbb19c6824754f"
+dependencies = [
+ "p3-util",
+ "tracing-forest",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "slop-whir"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71f6a16450fc701450831121810da91c6ee3ac50e4705327dcd4957b046015a"
+dependencies = [
+ "derive-where",
+ "futures",
+ "itertools 0.14.0",
+ "rand 0.8.5",
+ "rayon",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-baby-bear",
+ "slop-basefold",
+ "slop-challenger",
+ "slop-commit",
+ "slop-dft",
+ "slop-jagged",
+ "slop-koala-bear",
+ "slop-matrix",
+ "slop-merkle-tree",
+ "slop-multilinear",
+ "slop-stacked",
+ "slop-tensor",
+ "slop-utils",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6283,49 +6845,50 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "5.2.3"
+version = "6.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7bcc9e463a19749f6080f69ee6410aadda0576115d60bed68d2ebc2d8af3fe4"
+checksum = "38fe5854ea3054c20b34fe85b08437583174e8cd71e612fcfef67ea841daea14"
 dependencies = [
  "anyhow",
  "cargo_metadata",
  "chrono",
  "clap",
  "dirs",
- "sp1-prover",
+ "sp1-primitives",
 ]
 
 [[package]]
 name = "sp1-core-executor"
-version = "5.2.3"
+version = "6.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb8bc70057a88164e479e367e2f83f7e7fba52d66acfbeef3b2174dc98c3627"
+checksum = "5cc9268de48a534ccb82287a517c0a07ee594136bc9fce6c7eb438c69e7917be"
 dependencies = [
  "bincode",
  "bytemuck",
+ "cfg-if",
  "clap",
+ "deepsize2",
  "elf",
  "enum-map",
  "eyre",
  "hashbrown 0.14.5",
  "hex",
- "itertools 0.13.0",
- "nohash-hasher",
+ "itertools 0.14.0",
+ "memmap2",
  "num",
- "p3-baby-bear",
- "p3-field",
- "p3-maybe-rayon",
- "p3-util",
- "rand 0.8.5",
- "range-set-blaze",
  "rrs-succinct",
  "serde",
+ "serde_arrays",
  "serde_json",
+ "slop-air",
+ "slop-algebra",
+ "slop-maybe-rayon",
+ "slop-symmetric",
  "sp1-curves",
+ "sp1-hypercube",
+ "sp1-jit",
  "sp1-primitives",
- "sp1-stark",
- "strum 0.26.3",
- "strum_macros 0.26.4",
+ "strum",
  "subenum",
  "thiserror 1.0.69",
  "tiny-keccak",
@@ -6336,114 +6899,172 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "5.2.3"
+version = "6.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe446bea36feb189af83cda6ea5420150e877764e2ed4ab4cb2ee5cd3e20355c"
+checksum = "d436300d3052341854e58c88a9b5444a6f45689ee8933f9bec047ac367693182"
 dependencies = [
  "bincode",
- "cbindgen",
- "cc",
  "cfg-if",
- "elliptic-curve 0.13.8",
+ "enum-map",
+ "futures",
  "generic-array 1.1.0",
- "glob",
  "hashbrown 0.14.5",
- "hex",
- "itertools 0.13.0",
- "k256",
+ "itertools 0.14.0",
  "num",
  "num_cpus",
- "p256 0.13.2",
- "p3-air",
- "p3-baby-bear",
- "p3-challenger",
- "p3-field",
- "p3-keccak-air",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-poseidon2",
- "p3-symmetric",
- "p3-uni-stark",
- "p3-util",
- "pathdiff",
- "rand 0.8.5",
  "rayon",
  "rayon-scan",
+ "rrs-succinct",
  "serde",
  "serde_json",
- "size",
+ "slop-air",
+ "slop-algebra",
+ "slop-challenger",
+ "slop-futures",
+ "slop-keccak-air",
+ "slop-matrix",
+ "slop-maybe-rayon",
+ "slop-uni-stark",
  "snowbridge-amcl",
  "sp1-core-executor",
  "sp1-curves",
  "sp1-derive",
+ "sp1-hypercube",
+ "sp1-jit",
  "sp1-primitives",
- "sp1-stark",
  "static_assertions",
- "strum 0.26.3",
- "strum_macros 0.26.4",
+ "strum",
+ "sysinfo 0.30.13",
  "tempfile",
  "thiserror 1.0.69",
+ "tokio",
  "tracing",
  "tracing-forest",
  "tracing-subscriber",
  "typenum",
- "web-time",
 ]
 
 [[package]]
 name = "sp1-cuda"
-version = "5.2.3"
+version = "6.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae79f89725c6e21dadb62be31a1c218292f5489559a848faf533419c722a3b3b"
+checksum = "a03bb846daaabe6e94af5e5199aa110b42c68482d6380b7e765d9d6b65119d52"
 dependencies = [
  "bincode",
- "ctrlc",
- "prost",
+ "bytes",
+ "reqwest",
  "serde",
+ "serde_json",
+ "sp1-core-executor",
  "sp1-core-machine",
+ "sp1-primitives",
  "sp1-prover",
+ "sp1-prover-types",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
- "twirp-rs",
 ]
 
 [[package]]
 name = "sp1-curves"
-version = "5.2.3"
+version = "6.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a7ce14c504360349f3eda564a0c9de286c35e1dfbcc979921a3384db02ae82"
+checksum = "1e3ad4fc0f5ea7286fbe5c788d97125dc0cb40eb81f15becb432a65f350cd2f9"
 dependencies = [
  "cfg-if",
  "dashu",
  "elliptic-curve 0.13.8",
  "generic-array 1.1.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "k256",
  "num",
  "p256 0.13.2",
- "p3-field",
  "serde",
+ "slop-algebra",
  "snowbridge-amcl",
  "sp1-primitives",
- "sp1-stark",
  "typenum",
 ]
 
 [[package]]
 name = "sp1-derive"
-version = "5.2.3"
+version = "6.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1144840e0b75e988f3b8d24ffd015bc5fd76599f7864bfd994f3eaf2eb261a"
+checksum = "f111a90749619066fbd7ba102b22375bc6c824abb66804c3184ba0f650d017a2"
 dependencies = [
+ "proc-macro2",
  "quote",
  "syn 1.0.109",
 ]
 
 [[package]]
-name = "sp1-lib"
-version = "5.2.3"
+name = "sp1-hypercube"
+version = "6.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1a9935d58cb1dcd757a1b10d727090f5b718f1f03b512d48f0c1952e6ead00"
+checksum = "caff340db83b2c38b01f022624b8b792c38f201417581d6855dbe9a445d2485f"
+dependencies = [
+ "arrayref",
+ "deepsize2",
+ "derive-where",
+ "futures",
+ "hashbrown 0.14.5",
+ "itertools 0.14.0",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "num_cpus",
+ "rayon",
+ "rayon-scan",
+ "serde",
+ "slop-air",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-basefold",
+ "slop-basefold-prover",
+ "slop-bn254",
+ "slop-challenger",
+ "slop-commit",
+ "slop-futures",
+ "slop-jagged",
+ "slop-koala-bear",
+ "slop-matrix",
+ "slop-merkle-tree",
+ "slop-multilinear",
+ "slop-poseidon2",
+ "slop-stacked",
+ "slop-sumcheck",
+ "slop-symmetric",
+ "slop-tensor",
+ "slop-uni-stark",
+ "slop-whir",
+ "sp1-derive",
+ "sp1-primitives",
+ "strum",
+ "thiserror 1.0.69",
+ "thousands",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "sp1-jit"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcadaa9206d36ae953c1b4390373879281ef1423115aa180e7ef0e82259d92aa"
+dependencies = [
+ "dynasmrt",
+ "hashbrown 0.14.5",
+ "memfd",
+ "memmap2",
+ "serde",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "sp1-lib"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "517e820776910468611149dda66791bdb700c1b7d68b96f0ea2e604f00ad8771"
 dependencies = [
  "bincode",
  "elliptic-curve 0.13.8",
@@ -6453,323 +7074,337 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "5.2.3"
+version = "6.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7d2a6187e394c30097ea7a975a4832f172918690dc89a979f0fad67422d3a8b"
+checksum = "0f395525b4fc46d37136f45be264c81718a67f4409c14c547ff491a263e019e7"
 dependencies = [
  "bincode",
  "blake3",
- "cfg-if",
+ "elf",
  "hex",
+ "itertools 0.14.0",
  "lazy_static",
  "num-bigint 0.4.6",
- "p3-baby-bear",
- "p3-field",
- "p3-poseidon2",
- "p3-symmetric",
  "serde",
  "sha2",
+ "slop-algebra",
+ "slop-bn254",
+ "slop-challenger",
+ "slop-koala-bear",
+ "slop-poseidon2",
+ "slop-primitives",
+ "slop-symmetric",
 ]
 
 [[package]]
 name = "sp1-prover"
-version = "5.2.3"
+version = "6.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc62e3139fdb1671067987f78ca85a24ea34dbc2f61dbbe3f92b9739e7aa2b9"
+checksum = "c64545387a6b5ee58155d75183223a8f19961e23d76a13a49c16514896e52ff7"
 dependencies = [
  "anyhow",
  "bincode",
  "clap",
  "dirs",
  "downloader",
+ "either",
  "enum-map",
  "eyre",
- "hashbrown 0.14.5",
- "hex",
- "itertools 0.13.0",
- "lru 0.12.5",
- "num-bigint 0.4.6",
- "p3-baby-bear",
- "p3-bn254-fr",
- "p3-challenger",
- "p3-commit",
- "p3-field",
- "p3-matrix",
- "p3-symmetric",
- "p3-util",
- "rayon",
- "serde",
- "serde_json",
- "serial_test",
- "sha2",
- "sp1-core-executor",
- "sp1-core-machine",
- "sp1-primitives",
- "sp1-recursion-circuit",
- "sp1-recursion-compiler",
- "sp1-recursion-core",
- "sp1-recursion-gnark-ffi",
- "sp1-stark",
- "sp1-verifier",
- "thiserror 1.0.69",
- "tracing",
- "tracing-appender",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "sp1-recursion-circuit"
-version = "5.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f16af7722bb0f7adabbfc0e60b7fe71ca546959d251c450afb79daaa589c56"
-dependencies = [
- "hashbrown 0.14.5",
- "itertools 0.13.0",
- "num-traits",
- "p3-air",
- "p3-baby-bear",
- "p3-bn254-fr",
- "p3-challenger",
- "p3-commit",
- "p3-dft",
- "p3-field",
- "p3-fri",
- "p3-matrix",
- "p3-symmetric",
- "p3-uni-stark",
- "p3-util",
- "rand 0.8.5",
- "rayon",
- "serde",
- "sp1-core-executor",
- "sp1-core-machine",
- "sp1-derive",
- "sp1-primitives",
- "sp1-recursion-compiler",
- "sp1-recursion-core",
- "sp1-recursion-gnark-ffi",
- "sp1-stark",
- "tracing",
-]
-
-[[package]]
-name = "sp1-recursion-compiler"
-version = "5.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c83564beb23361e0b93d64f3b8d4a503eac8ced246648f727d44b0827165014"
-dependencies = [
- "backtrace",
- "itertools 0.13.0",
- "p3-baby-bear",
- "p3-bn254-fr",
- "p3-field",
- "p3-symmetric",
- "serde",
- "sp1-core-machine",
- "sp1-primitives",
- "sp1-recursion-core",
- "sp1-recursion-derive",
- "sp1-stark",
- "tracing",
- "vec_map",
-]
-
-[[package]]
-name = "sp1-recursion-core"
-version = "5.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c209fa6e384ff56ea7761ccc65426da08516d72ae55b6d8e4021b58bd4022f8"
-dependencies = [
- "backtrace",
- "cbindgen",
- "cc",
- "cfg-if",
- "ff 0.13.1",
- "glob",
- "hashbrown 0.14.5",
- "itertools 0.13.0",
- "num_cpus",
- "p3-air",
- "p3-baby-bear",
- "p3-bn254-fr",
- "p3-challenger",
- "p3-commit",
- "p3-dft",
- "p3-field",
- "p3-fri",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-merkle-tree",
- "p3-poseidon2",
- "p3-symmetric",
- "p3-util",
- "pathdiff",
- "rand 0.8.5",
- "serde",
- "sp1-core-machine",
- "sp1-derive",
- "sp1-primitives",
- "sp1-stark",
- "static_assertions",
- "thiserror 1.0.69",
- "tracing",
- "vec_map",
- "zkhash",
-]
-
-[[package]]
-name = "sp1-recursion-derive"
-version = "5.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8ca2e82fea312a406f4ad4cba1a11812da4cea806607c56ec1670fd55b2ea6"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "sp1-recursion-gnark-ffi"
-version = "5.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e146d24ce91c08e36b270a73de9817b9847e759a3d66923b009c67f24a3b9b2"
-dependencies = [
- "anyhow",
- "bincode",
- "bindgen 0.70.1",
- "cc",
- "cfg-if",
- "hex",
- "num-bigint 0.4.6",
- "p3-baby-bear",
- "p3-field",
- "p3-symmetric",
- "serde",
- "serde_json",
- "sha2",
- "sp1-core-machine",
- "sp1-recursion-compiler",
- "sp1-stark",
- "tempfile",
- "tracing",
-]
-
-[[package]]
-name = "sp1-sdk"
-version = "5.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9655067dcadba91f01491729cc78a60ad3a5ffaaf9adab817502f729ddb3761"
-dependencies = [
- "alloy-primitives",
- "alloy-signer",
- "alloy-signer-aws",
- "alloy-signer-local",
- "alloy-sol-types",
- "anyhow",
- "async-trait",
- "aws-config",
- "aws-sdk-kms",
- "backoff",
- "bincode",
- "cfg-if",
- "dirs",
- "eventsource-stream",
  "futures",
  "hashbrown 0.14.5",
  "hex",
  "indicatif",
- "itertools 0.13.0",
- "k256",
- "p3-baby-bear",
- "p3-field",
- "p3-fri",
- "prost",
+ "itertools 0.14.0",
+ "lru 0.12.5",
+ "mti",
+ "num-bigint 0.4.6",
+ "opentelemetry",
+ "pin-project",
+ "rand 0.8.5",
  "reqwest",
- "reqwest-middleware",
- "rustls 0.23.27",
  "serde",
  "serde_json",
- "sp1-build",
+ "serial_test",
+ "sha2",
+ "slop-air",
+ "slop-algebra",
+ "slop-basefold",
+ "slop-bn254",
+ "slop-challenger",
+ "slop-futures",
+ "slop-jagged",
+ "slop-multilinear",
+ "slop-stacked",
+ "slop-symmetric",
  "sp1-core-executor",
  "sp1-core-machine",
- "sp1-cuda",
+ "sp1-derive",
+ "sp1-hypercube",
+ "sp1-jit",
  "sp1-primitives",
- "sp1-prover",
- "sp1-stark",
- "strum 0.26.3",
- "strum_macros 0.26.4",
+ "sp1-prover-types",
+ "sp1-recursion-circuit",
+ "sp1-recursion-compiler",
+ "sp1-recursion-executor",
+ "sp1-recursion-gnark-ffi",
+ "sp1-recursion-machine",
+ "sp1-verifier",
+ "static_assertions",
  "sysinfo 0.30.13",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tonic",
  "tracing",
- "twirp-rs",
+ "tracing-appender",
+ "tracing-subscriber",
 ]
 
 [[package]]
-name = "sp1-stark"
-version = "5.2.3"
+name = "sp1-prover-types"
+version = "6.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40477690a0bb6d7102322947407439a8f1d05aecd535f0081db05e9a31f808f2"
+checksum = "834512266314b8dd35fd52b921d62abb113c3c35b27358acdbc178b3a17ec72e"
 dependencies = [
- "arrayref",
+ "anyhow",
+ "async-scoped",
+ "bincode",
+ "chrono",
+ "futures-util",
  "hashbrown 0.14.5",
- "itertools 0.13.0",
- "num-bigint 0.4.6",
- "num-traits",
- "p3-air",
- "p3-baby-bear",
- "p3-challenger",
- "p3-commit",
- "p3-dft",
- "p3-field",
- "p3-fri",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-merkle-tree",
- "p3-poseidon2",
- "p3-symmetric",
- "p3-uni-stark",
- "p3-util",
- "rayon-scan",
+ "mti",
+ "prost",
  "serde",
+ "tokio",
+ "tonic",
+ "tonic-build",
+ "tracing",
+]
+
+[[package]]
+name = "sp1-recursion-circuit"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "105531a782d66030eab608832e0829e4699053a6d41cd3c2c7931def9c9540fb"
+dependencies = [
+ "bincode",
+ "itertools 0.14.0",
+ "rand 0.8.5",
+ "rayon",
+ "serde",
+ "slop-air",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-basefold",
+ "slop-basefold-prover",
+ "slop-bn254",
+ "slop-challenger",
+ "slop-commit",
+ "slop-jagged",
+ "slop-koala-bear",
+ "slop-matrix",
+ "slop-merkle-tree",
+ "slop-multilinear",
+ "slop-stacked",
+ "slop-sumcheck",
+ "slop-symmetric",
+ "slop-tensor",
+ "slop-whir",
+ "sp1-core-executor",
+ "sp1-core-machine",
  "sp1-derive",
+ "sp1-hypercube",
  "sp1-primitives",
- "strum 0.26.3",
- "sysinfo 0.30.13",
+ "sp1-recursion-compiler",
+ "sp1-recursion-executor",
+ "sp1-recursion-machine",
+ "tracing",
+]
+
+[[package]]
+name = "sp1-recursion-compiler"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ab98d241444285539b0d4203288fbe9887707c355e346cfb176b461524c58d"
+dependencies = [
+ "backtrace",
+ "cfg-if",
+ "itertools 0.14.0",
+ "serde",
+ "slop-algebra",
+ "slop-bn254",
+ "slop-symmetric",
+ "sp1-core-machine",
+ "sp1-hypercube",
+ "sp1-primitives",
+ "sp1-recursion-executor",
+ "tracing",
+ "vec_map",
+]
+
+[[package]]
+name = "sp1-recursion-executor"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc69767dce218874edbef09515ccc5fb32d5e6b857a95a99944a66f6f405f5b1"
+dependencies = [
+ "backtrace",
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "itertools 0.14.0",
+ "range-set-blaze",
+ "serde",
+ "slop-algebra",
+ "slop-maybe-rayon",
+ "slop-poseidon2",
+ "slop-symmetric",
+ "smallvec",
+ "sp1-derive",
+ "sp1-hypercube",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "sp1-recursion-gnark-ffi"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f526cb636baa1ad67f1410884e7a5580b7068beee3ee88609fb39f906bab27b3"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "bindgen 0.70.1",
+ "cfg-if",
+ "hex",
+ "num-bigint 0.4.6",
+ "serde",
+ "serde_json",
+ "sha2",
+ "slop-algebra",
+ "slop-symmetric",
+ "sp1-hypercube",
+ "sp1-primitives",
+ "sp1-recursion-compiler",
+ "sp1-verifier",
+ "tempfile",
+ "tracing",
+]
+
+[[package]]
+name = "sp1-recursion-machine"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "228ec6719240b0933289332d730be328d3a3e4f9e6ff9ee2e20ec2b4a99aeed9"
+dependencies = [
+ "itertools 0.14.0",
+ "rand 0.8.5",
+ "slop-air",
+ "slop-algebra",
+ "slop-basefold",
+ "slop-matrix",
+ "slop-maybe-rayon",
+ "slop-symmetric",
+ "sp1-derive",
+ "sp1-hypercube",
+ "sp1-primitives",
+ "sp1-recursion-executor",
+ "strum",
+ "tracing",
+ "zkhash",
+]
+
+[[package]]
+name = "sp1-sdk"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d8dae789acfa3b4e8211234d05901c28cd1b988f230c9db0c29207fa131071a"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bincode",
+ "cfg-if",
+ "dirs",
+ "eventsource-stream",
+ "futures",
+ "hex",
+ "indicatif",
+ "itertools 0.14.0",
+ "k256",
+ "num-bigint 0.4.6",
+ "serde",
+ "sha2",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-basefold",
+ "slop-commit",
+ "slop-jagged",
+ "slop-merkle-tree",
+ "slop-multilinear",
+ "slop-stacked",
+ "slop-sumcheck",
+ "slop-tensor",
+ "sp1-build",
+ "sp1-core-executor",
+ "sp1-core-machine",
+ "sp1-cuda",
+ "sp1-hypercube",
+ "sp1-primitives",
+ "sp1-prover",
+ "sp1-prover-types",
+ "sp1-recursion-executor",
+ "sp1-recursion-gnark-ffi",
+ "sp1-verifier",
+ "strum",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "sp1-verifier"
-version = "5.2.3"
+version = "6.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f95bd323fde5d19116873b29e5f8e20da371466d70185732bbfd3511ca0fd31"
+checksum = "f11dd15bf0dc2325ced1f3bb58bfed84efc5228a09127ab6787ee5103514f09e"
 dependencies = [
+ "bincode",
  "blake3",
  "cfg-if",
+ "dirs",
  "hex",
  "lazy_static",
+ "serde",
  "sha2",
- "substrate-bn-succinct",
+ "slop-algebra",
+ "slop-challenger",
+ "slop-primitives",
+ "slop-symmetric",
+ "sp1-hypercube",
+ "sp1-primitives",
+ "sp1-recursion-executor",
+ "sp1-recursion-machine",
+ "strum",
+ "substrate-bn-succinct-rs",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "sp1-zkvm"
-version = "5.2.3"
+version = "6.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e767ed85f89b1c8d84188c2cc035833079529bb0ddd8f7bd252de91ce562acc7"
+checksum = "45aa8c53b0332dcce1f588185df97e8ed9e7a6b37b0c6584f29674017628831f"
 dependencies = [
  "cfg-if",
+ "critical-section",
+ "embedded-alloc",
  "getrandom 0.2.16",
  "getrandom 0.3.3",
  "lazy_static",
  "libm",
- "p3-baby-bear",
- "p3-field",
  "rand 0.8.5",
  "sha2",
+ "slop-algebra",
  "sp1-lib",
  "sp1-primitives",
 ]
@@ -6836,8 +7471,10 @@ name = "spn-calibrator"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "sp1-build",
  "sp1-sdk",
+ "tokio",
  "tracing",
 ]
 
@@ -7009,6 +7646,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7016,33 +7659,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
 dependencies = [
- "strum_macros 0.27.1",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.101",
+ "strum_macros",
 ]
 
 [[package]]
@@ -7071,10 +7692,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "substrate-bn-succinct"
-version = "0.6.0-v5.0.0"
+name = "substrate-bn-succinct-rs"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ba32f1b74728f92887c3ad17c42bf82998eb52c9091018f35294e9cd388b0c8"
+checksum = "a241fd7c1016fb8ad30fcf5a20986c0c4538e8f15a1b41a1761516299e377ec1"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -7084,7 +7705,6 @@ dependencies = [
  "num-bigint 0.4.6",
  "rand 0.8.5",
  "rustc-hex",
- "sp1-lib",
 ]
 
 [[package]]
@@ -7092,6 +7712,19 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "svgbobdoc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2c04b93fc15d79b39c63218f15e3fdffaa4c227830686e3b7c5f41244eb3e50"
+dependencies = [
+ "base64 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "unicode-width 0.1.14",
+]
 
 [[package]]
 name = "syn"
@@ -7282,6 +7915,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
+
+[[package]]
 name = "thread_local"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7334,10 +7973,11 @@ dependencies = [
 [[package]]
 name = "tiny-keccak"
 version = "2.0.2"
-source = "git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-4.0.0#d2ffd330259c8f290b07d99cc1ef1f74774382c2"
+source = "git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-6.0.0#957430a459f7a2332ab5bab4a12f9b473bb95c87"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "sp1-lib",
 ]
 
 [[package]]
@@ -7450,25 +8090,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit 0.22.26",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "toml_edit"
@@ -7488,18 +8113,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
  "indexmap 2.9.0",
- "serde",
- "serde_spanned",
  "toml_datetime",
- "toml_write",
  "winnow 0.7.10",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 
 [[package]]
 name = "tonic"
@@ -7716,31 +8332,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "twirp-rs"
-version = "0.13.0-succinct"
+name = "typeid_prefix"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27dfcc06b8d9262bc2d4b8d1847c56af9971a52dd8a0076876de9db763227d0d"
+checksum = "a9da1387307fdee46aa441e4f08a1b491e659fcac1aca9cd71f2c624a0de5d1b"
+
+[[package]]
+name = "typeid_suffix"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77b55e96f110c6db5d1a2f24072552537f0091dc90cebeaa679540bac93e7405"
 dependencies = [
- "async-trait",
- "axum",
- "futures",
- "http 1.3.1",
- "http-body-util",
- "hyper 1.6.0",
- "prost",
- "reqwest",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tower 0.5.2",
- "url",
+ "uuid",
 ]
 
 [[package]]
@@ -7838,7 +8457,11 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
+ "atomic",
+ "getrandom 0.3.3",
  "js-sys",
+ "md-5",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 
@@ -7857,6 +8480,7 @@ dependencies = [
  "sp1-sdk",
  "sp1-zkvm",
  "spn-vapp-core",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1621,8 +1621,6 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
- "log",
- "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
@@ -2105,6 +2103,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "crash-context"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031ed29858d90cfdf27fe49fae28028a1f20466db97962fa2f4ea34809aeebf3"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "mach2",
+]
+
+[[package]]
+name = "crash-handler"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0df5c9639f4942eb7702b964b3f9adf03a55724a57558cc177407388a8b936e2"
+dependencies = [
+ "cfg-if",
+ "crash-context",
+ "libc",
+ "mach2",
+ "parking_lot",
+]
+
+[[package]]
 name = "crc"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2580,20 +2602,6 @@ name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
-
-[[package]]
-name = "downloader"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac1e888d6830712d565b2f3a974be3200be9296bc1b03db8251a4cbf18a4a34"
-dependencies = [
- "digest 0.10.7",
- "futures",
- "rand 0.8.5",
- "reqwest",
- "thiserror 1.0.69",
- "tokio",
-]
 
 [[package]]
 name = "dunce"
@@ -3909,9 +3917,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -6379,18 +6387,18 @@ dependencies = [
 
 [[package]]
 name = "slop-air"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "242539aba9e5424923d7bd629775570c7d10ec28584e96ea599575a51bedcde8"
+checksum = "9bfd4c0fb41e0638afd60ce2ebf74d59225e3c20e25b8f202912c8a38f793de4"
 dependencies = [
  "p3-air",
 ]
 
 [[package]]
 name = "slop-algebra"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "691beea96fd18d4881f9ca1cb4e58194dac6366f24956a2fdae00c8ee382a0c9"
+checksum = "733912d564a68ff209707e71fdc517d4ff82d4362b6a409f6a8241dfcb7a576a"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -6399,9 +6407,9 @@ dependencies = [
 
 [[package]]
 name = "slop-alloc"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b7800cba9b31377f9353174d13fd8e39608b6f1d1531f0e92b8ce4af49ae0"
+checksum = "0ee6cc091290f9db6e3d3452430970f5234dbd270541300c9554d8172e18d0c2"
 dependencies = [
  "serde",
  "slop-algebra",
@@ -6410,9 +6418,9 @@ dependencies = [
 
 [[package]]
 name = "slop-baby-bear"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949e3c822532a87b4ad04f7280283c256621b0a83aee1b40cbd721df29df641d"
+checksum = "3f0138bae78c3d8f1691ee28315dd87b3d71c0b71e51e7b9eabf8d2e6ffffcfa"
 dependencies = [
  "lazy_static",
  "p3-baby-bear",
@@ -6425,9 +6433,9 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58984f92091a668a006b6895487079d99209e599b02d636f061fe4ae26977fb5"
+checksum = "272d5e3082f066bcdd6ded60e3dd403a7697f4bbfaeea4c4e00f088bd555305e"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -6448,9 +6456,9 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold-prover"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86eb8581b52f97860242fe5e8d6b49d2a37e1b38d4a647adf24acaa2965ee7d"
+checksum = "175433ed8fc9a45fcb835b4375bbe54c5df0022b920f248055da6ae99e141104"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -6475,9 +6483,9 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1852499c245f7f3dec23408b4930b3ea7570ae914b9c31f12950ac539d85ee"
+checksum = "a71b23ede427299e139fb822c5d0ea8fb931dc297eba0c6e2f30f774c04ebc81"
 dependencies = [
  "ff 0.13.1",
  "p3-bn254-fr",
@@ -6491,9 +6499,9 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4349af93602f3876a3eda948a74d9d16d774c401dfe25f41a45ffd84f230bc1"
+checksum = "59e4993210936ab317c0d56ee8257e1cdfe6c2fae4df1e158737f034e21d45f9"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -6504,9 +6512,9 @@ dependencies = [
 
 [[package]]
 name = "slop-commit"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "584339690d20fb6b34b0dc957cbd267221ba2ab7b0c1292c118378f3498979c4"
+checksum = "afe1a49612ffedb6a44825ccbaa54ea53670a61366b8112a80865fef462630f9"
 dependencies = [
  "p3-commit",
  "serde",
@@ -6515,9 +6523,9 @@ dependencies = [
 
 [[package]]
 name = "slop-dft"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "148281e1611ca570d016a733aac2f3ec9867241cc800a96d15bc6ecfd010daf7"
+checksum = "b1fe8ca56f2cb47f22658f923e8d1a97413bb89ecc4e7185722ec406e61b82e9"
 dependencies = [
  "p3-dft",
  "serde",
@@ -6529,18 +6537,18 @@ dependencies = [
 
 [[package]]
 name = "slop-fri"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0857a346ea28496ee56b1dcad192db8c7ff0455a18bfd67ce6513323b594b746"
+checksum = "434a8e3f5fc6c5a1973a3c3964b4589af26c74bd480fd7cd6dcb0feb7d7e8f92"
 dependencies = [
  "p3-fri",
 ]
 
 [[package]]
 name = "slop-futures"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bbfea5447d243572da7aae8d5e57856229a97fb8bc6a42439d4c5f4de951ee0"
+checksum = "69e76ea10d2865798d6a9c39faffbc2c23c0bbf34a6e449e83de409aa265171a"
 dependencies = [
  "crossbeam",
  "futures",
@@ -6553,9 +6561,9 @@ dependencies = [
 
 [[package]]
 name = "slop-jagged"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc420430b93d38e9aae903bc4bc11c342f8d49d015cca26eeb36a6ea3f7a0f1f"
+checksum = "8677ede7f5b5f1fa19884ba07b6120cbb74b4e4ff4cb56cd068e01fffd4e603b"
 dependencies = [
  "derive-where",
  "futures",
@@ -6587,18 +6595,18 @@ dependencies = [
 
 [[package]]
 name = "slop-keccak-air"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "288abf40d9901f79e221ece87f11324826289bf5d694fde07dd785bdb4afda38"
+checksum = "794162816eb0c8869f2bf09881ac6a7c808da1aab11e097ca25460e4ef895cc7"
 dependencies = [
  "p3-keccak-air",
 ]
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "574784c044d11cf9d8238dc18bce9b897bc34d0fb1daaceafd75ebb400084016"
+checksum = "8986e94b9a43d58fc8ce5bf111b0985479ab888ced923e3052fb19943f7859b4"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -6611,27 +6619,27 @@ dependencies = [
 
 [[package]]
 name = "slop-matrix"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd1117c395388bd172826115ac4f9a7e09bf9c937ceafa82194132a058e27c0d"
+checksum = "a89bef0d6e09bc5431c6b50b3eee460722ca9eb569dffcdec582bd1d72db496c"
 dependencies = [
  "p3-matrix",
 ]
 
 [[package]]
 name = "slop-maybe-rayon"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81316cfe721c3f47cd0af63002a8b6557c951ff9588fa7db0f4f3b99af091486"
+checksum = "e135011bcdae048b9e85f42ba95cc8dc69cb4f5566289044cabe67a6ac65e6e0"
 dependencies = [
  "p3-maybe-rayon",
 ]
 
 [[package]]
 name = "slop-merkle-tree"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e700652778c15320f6269362103b87a3787a7c9d70fb05d9742dbce66c46f764"
+checksum = "748e3fb2d76fd2e2017d9e544072a8318efc1deac6277b5721d31381a674d505"
 dependencies = [
  "derive-where",
  "ff 0.13.1",
@@ -6650,15 +6658,16 @@ dependencies = [
  "slop-poseidon2",
  "slop-symmetric",
  "slop-tensor",
+ "slop-utils",
  "thiserror 1.0.69",
  "zkhash",
 ]
 
 [[package]]
 name = "slop-multilinear"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6151db452ace0d960314f46c61a2b8d45e1fa4dfd5830447c67fc1e1e1e823b5"
+checksum = "b579ce845ca26e0c2750d11f09327add269e4b695c21b35f1659f49b9bd08311"
 dependencies = [
  "derive-where",
  "futures",
@@ -6677,27 +6686,27 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5af617970b63e8d7199204bc02996745b6c35c39f2b513a118c62c7b1a0b2f1b"
+checksum = "5b06e4a24cba104a0a39740eedd97e60e8896926cc38e6a58d5866cc9811affa"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58d82c53508f3ebff8acdabb5db2584f37686257a2549a17c977cf30cd9e24e6"
+checksum = "0b0b66701c82f6aab97f4990b5d9ed7463beb5b5042dbe5eda5f6c71a6207b35"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-stacked"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a25c9fb9c908a2d10037934e2c299d30f98a2146f6ded87a7b529b05ddbfda27"
+checksum = "8992c338b13abe792faf62000a47096f08817ea655036c530990b1c60c5ff256"
 dependencies = [
  "derive-where",
  "futures",
@@ -6718,9 +6727,9 @@ dependencies = [
 
 [[package]]
 name = "slop-sumcheck"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05c691f34c05e933777059a10804e00f77834b927abc2701f5f394e9c2b49c1c"
+checksum = "45fdcab8b7e0fa43b808112fd1c387eabfa7e09435c6a4fb92e45b917971ade8"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -6736,18 +6745,18 @@ dependencies = [
 
 [[package]]
 name = "slop-symmetric"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15acfa7f567ffa4f36de134492632a397c33fa6af2e48894e50978b52eeeb871"
+checksum = "e6d159948b924fd00f280064d7a049e43dceb2f26067f32fb99570d3169969ee"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "slop-tensor"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1796e5ff7dcdcd2c15f423a27550a4688e25009bd5ca648d9593d66f243950d6"
+checksum = "f0a6b65130a06d1b1a24ab4928e1eadc5a6e14f35c171c0e69d5b9cf6c4d56e9"
 dependencies = [
  "arrayvec",
  "derive-where",
@@ -6765,18 +6774,18 @@ dependencies = [
 
 [[package]]
 name = "slop-uni-stark"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504f32330985e48a6aa9c9e0985641a4dc084d3843ff59075591b24b818f2a67"
+checksum = "b3655347bb0dc0e559a63fa8c5053a79d9d0258af04b6b3bebfc51fff880416a"
 dependencies = [
  "p3-uni-stark",
 ]
 
 [[package]]
 name = "slop-utils"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba510663661800990c1207ddbf3a1e67a551f05d882a60197adbb19c6824754f"
+checksum = "4fad36458e05b6ccc8ebe951734e9d036128eb0f01596824e1104a37b3216654"
 dependencies = [
  "p3-util",
  "tracing-forest",
@@ -6785,9 +6794,9 @@ dependencies = [
 
 [[package]]
 name = "slop-whir"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71f6a16450fc701450831121810da91c6ee3ac50e4705327dcd4957b046015a"
+checksum = "d104106013cf050132b47d73568b4562e273c0dda3a1d304a96afab25737d414"
 dependencies = [
  "derive-where",
  "futures",
@@ -6844,9 +6853,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38fe5854ea3054c20b34fe85b08437583174e8cd71e612fcfef67ea841daea14"
+checksum = "7321136acefff985b0fb201b84359d609451bbd0a63203d4b601eaabe28da14f"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -6858,9 +6867,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc9268de48a534ccb82287a517c0a07ee594136bc9fce6c7eb438c69e7917be"
+checksum = "89e911afd7e96cab3936e275445e23d1e6cb26776bd06223cb4466e812b13b54"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -6897,10 +6906,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp1-core-machine"
-version = "6.0.2"
+name = "sp1-core-executor-runner"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d436300d3052341854e58c88a9b5444a6f45689ee8933f9bec047ac367693182"
+checksum = "b3bf24cda2b466c097e62a60a3e1ac7ff014d7972f4ff350d72ff2b89eff5128"
+dependencies = [
+ "base64 0.22.1",
+ "bincode",
+ "cargo_metadata",
+ "hashbrown 0.14.5",
+ "hex",
+ "libc",
+ "sha2",
+ "sp1-core-executor",
+ "sp1-core-executor-runner-binary",
+ "sp1-jit",
+ "sp1-primitives",
+ "sysinfo 0.30.13",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "sp1-core-executor-runner-binary"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf22b7b1696ce686f79efb99a543a10b0b82d1068834087d21f0fe3d76d9054d"
+dependencies = [
+ "bincode",
+ "crash-handler",
+ "libc",
+ "serde",
+ "sp1-core-executor",
+ "sp1-jit",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sp1-core-machine"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fd9328937306a831184febaae80c7b63ee15d3716573f0a34d62f5dee7408d"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -6926,6 +6972,7 @@ dependencies = [
  "slop-uni-stark",
  "snowbridge-amcl",
  "sp1-core-executor",
+ "sp1-core-executor-runner",
  "sp1-curves",
  "sp1-derive",
  "sp1-hypercube",
@@ -6944,31 +6991,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp1-cuda"
-version = "6.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a03bb846daaabe6e94af5e5199aa110b42c68482d6380b7e765d9d6b65119d52"
-dependencies = [
- "bincode",
- "bytes",
- "reqwest",
- "serde",
- "serde_json",
- "sp1-core-executor",
- "sp1-core-machine",
- "sp1-primitives",
- "sp1-prover",
- "sp1-prover-types",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "sp1-curves"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e3ad4fc0f5ea7286fbe5c788d97125dc0cb40eb81f15becb432a65f350cd2f9"
+checksum = "bf1e420a0980906ff8f875525664209395c7a5243243ff70283adb357e921ef2"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -6987,9 +7013,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f111a90749619066fbd7ba102b22375bc6c824abb66804c3184ba0f650d017a2"
+checksum = "caa1235972b67b86514c3f23ba690972b712dd009159c2e50f723d7ac02173d8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6998,9 +7024,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-hypercube"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caff340db83b2c38b01f022624b8b792c38f201417581d6855dbe9a445d2485f"
+checksum = "b8314d1620d659913912121a3ecae19d1384fdd06e43d954034cad8bd082f5db"
 dependencies = [
  "arrayref",
  "deepsize2",
@@ -7046,12 +7072,13 @@ dependencies = [
 
 [[package]]
 name = "sp1-jit"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcadaa9206d36ae953c1b4390373879281ef1423115aa180e7ef0e82259d92aa"
+checksum = "7e6b9a7102c21e5ecd5b65861188f068f17951a2db9bc3fd4f65cd5f9b0e8449"
 dependencies = [
  "dynasmrt",
  "hashbrown 0.14.5",
+ "libc",
  "memfd",
  "memmap2",
  "serde",
@@ -7061,9 +7088,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517e820776910468611149dda66791bdb700c1b7d68b96f0ea2e604f00ad8771"
+checksum = "9b96392c1b1c197beaa6b0806099a8d73643a09d5ac0874e26c9c5153a7fcb4c"
 dependencies = [
  "bincode",
  "elliptic-curve 0.13.8",
@@ -7073,9 +7100,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f395525b4fc46d37136f45be264c81718a67f4409c14c547ff491a263e019e7"
+checksum = "b6b77098dae9d62e080be3af253188c08e7e96e666423306654eede0110bf363"
 dependencies = [
  "bincode",
  "blake3",
@@ -7097,15 +7124,14 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64545387a6b5ee58155d75183223a8f19961e23d76a13a49c16514896e52ff7"
+checksum = "d4ba1691f53df50f8024f756c3a0e7b009e544e31c7297ae591eceba1d27232c"
 dependencies = [
  "anyhow",
  "bincode",
  "clap",
  "dirs",
- "downloader",
  "either",
  "enum-map",
  "eyre",
@@ -7136,6 +7162,7 @@ dependencies = [
  "slop-stacked",
  "slop-symmetric",
  "sp1-core-executor",
+ "sp1-core-executor-runner",
  "sp1-core-machine",
  "sp1-derive",
  "sp1-hypercube",
@@ -7161,9 +7188,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover-types"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "834512266314b8dd35fd52b921d62abb113c3c35b27358acdbc178b3a17ec72e"
+checksum = "011fe0b63d8b930665e5e6ca5f9f766c1b442727ec473d0baeea629d225c4360"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -7182,9 +7209,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "105531a782d66030eab608832e0829e4699053a6d41cd3c2c7931def9c9540fb"
+checksum = "ae1bb2594e6480d20c6d4be6099408df3a0de85bc956f0e74511c80515ac9e2d"
 dependencies = [
  "bincode",
  "itertools 0.14.0",
@@ -7222,9 +7249,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ab98d241444285539b0d4203288fbe9887707c355e346cfb176b461524c58d"
+checksum = "8e113c225149badeda05e679f169281cad6ef0480919f726e21acdfbf38848fb"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -7243,9 +7270,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-executor"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc69767dce218874edbef09515ccc5fb32d5e6b857a95a99944a66f6f405f5b1"
+checksum = "a8805b6ad230dbfc249a4c8a2ddb8cdad1053377739b7c8a6a78f06328170b63"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -7267,13 +7294,12 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f526cb636baa1ad67f1410884e7a5580b7068beee3ee88609fb39f906bab27b3"
+checksum = "1a7892c7c442aa109053998b360e91a26d776f63cb394fa50caf59ca626c08dd"
 dependencies = [
  "anyhow",
  "bincode",
- "bindgen 0.70.1",
  "cfg-if",
  "hex",
  "num-bigint 0.4.6",
@@ -7292,9 +7318,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-machine"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "228ec6719240b0933289332d730be328d3a3e4f9e6ff9ee2e20ec2b4a99aeed9"
+checksum = "2fb19db493ef086f0b5869e6c5ad52da728f265647a8a1f2bf765c3236eda6b0"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -7315,9 +7341,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d8dae789acfa3b4e8211234d05901c28cd1b988f230c9db0c29207fa131071a"
+checksum = "349ca86c7a88456c9f0fa1c8869e0d35bb63d6c811dc9ad8337c90909ce532ec"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7333,26 +7359,15 @@ dependencies = [
  "num-bigint 0.4.6",
  "serde",
  "sha2",
- "slop-algebra",
- "slop-alloc",
- "slop-basefold",
- "slop-commit",
- "slop-jagged",
- "slop-merkle-tree",
- "slop-multilinear",
- "slop-stacked",
- "slop-sumcheck",
- "slop-tensor",
  "sp1-build",
  "sp1-core-executor",
+ "sp1-core-executor-runner",
  "sp1-core-machine",
- "sp1-cuda",
  "sp1-hypercube",
  "sp1-primitives",
  "sp1-prover",
  "sp1-prover-types",
  "sp1-recursion-executor",
- "sp1-recursion-gnark-ffi",
  "sp1-verifier",
  "strum",
  "tempfile",
@@ -7363,9 +7378,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f11dd15bf0dc2325ced1f3bb58bfed84efc5228a09127ab6787ee5103514f09e"
+checksum = "f97f6c90e5f44ffaa18e0cf7aab2f4f02d0a2261aee21d4a48e09cc453ef0e0e"
 dependencies = [
  "bincode",
  "blake3",
@@ -7390,9 +7405,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45aa8c53b0332dcce1f588185df97e8ed9e7a6b37b0c6584f29674017628831f"
+checksum = "d31a7c3f072f248342284031684c9195e2264422964129c3b8652f9196ecc937"
 dependencies = [
  "cfg-if",
  "critical-section",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,5 +136,7 @@ socket2 = { version = "0.5", default-features = false }
 
 [patch.crates-io]
 sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.10.8-sp1-6.0.0" }
+sha3 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha3", tag = "patch-sha3-0.10.8-sp1-6.0.0" }
 tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", tag = "patch-2.0.2-sp1-6.0.0" }
 k256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-k256-13.4-sp1-6.0.0" }
+p256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-p256-13.2-sp1-6.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
-rust-version = "1.79"
+rust-version = "1.91"
 repository = "https://github.com/succinctlabs/sp1"
 keywords = ["sp1", "succinct", "zero-knowledge", "zkvm"]
 categories = ["cryptography"]
@@ -38,11 +38,11 @@ spn-network-types = { path = "crates/types/network" }
 spn-vapp-core = { path = "crates/vapp" }
 
 # sp1
-sp1-sdk = "5.2.3"
-sp1-prover = "5.2.3"
-sp1-verifier = "5.2.3"
-sp1-zkvm = "5.2.3"
-sp1-build = "5.2.3"
+sp1-sdk = "6.0.2"
+sp1-prover = "6.0.2"
+sp1-verifier = "6.0.2"
+sp1-zkvm = "6.0.2"
+sp1-build = "6.0.2"
 
 # aws
 aws-config = "1.5.3"
@@ -135,9 +135,6 @@ once_cell = "1.18.0"
 socket2 = { version = "0.5", default-features = false }
 
 [patch.crates-io]
-sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.10.8-sp1-4.0.0" }
-sha3-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha3", tag = "patch-sha3-0.10.8-sp1-4.0.0" }
-crypto-bigint = { git = "https://github.com/sp1-patches/RustCrypto-bigint", tag = "patch-0.5.5-sp1-4.0.0" }
-tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", tag = "patch-2.0.2-sp1-4.0.0" }
-k256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-k256-13.4-sp1-5.0.0" }
-p256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-p256-13.2-sp1-5.0.0" }
+sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.10.8-sp1-6.0.0" }
+tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", tag = "patch-2.0.2-sp1-6.0.0" }
+k256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-k256-13.4-sp1-6.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,11 +38,11 @@ spn-network-types = { path = "crates/types/network" }
 spn-vapp-core = { path = "crates/vapp" }
 
 # sp1
-sp1-sdk = "6.0.2"
-sp1-prover = "6.0.2"
-sp1-verifier = "6.0.2"
-sp1-zkvm = "6.0.2"
-sp1-build = "6.0.2"
+sp1-sdk = "6.1.0"
+sp1-prover = "6.1.0"
+sp1-verifier = "6.1.0"
+sp1-zkvm = "6.1.0"
+sp1-build = "6.1.0"
 
 # aws
 aws-config = "1.5.3"

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -13,7 +13,7 @@ use rustls::crypto::ring;
 use tabled::{settings::Style, Table, Tabled};
 use tracing::info;
 
-use sp1_sdk::{include_elf, SP1Stdin};
+use sp1_sdk::{include_elf, Elf, SP1Stdin};
 use spn_calibrator::{Calibrator, SinglePassCalibrator};
 use spn_network_types::prover_network_client::ProverNetworkClient;
 use spn_node_core::{Node, NodeContext, SerialBidder, SerialContext, SerialMonitor, SerialProver};
@@ -82,7 +82,7 @@ async fn main() -> Result<()> {
     match cli {
         Args::Calibrate(args) => {
             // Create the ELF.
-            const SPN_FIBONACCI_ELF: &[u8] = include_elf!("spn-fibonacci-program");
+            const SPN_FIBONACCI_ELF: Elf = include_elf!("spn-fibonacci-program");
 
             // Create a table for the input parameters.
             #[derive(Tabled)]
@@ -136,7 +136,7 @@ async fn main() -> Result<()> {
                 args.profit_margin,
             );
             let metrics =
-                calibrator.calibrate().map_err(|e| anyhow!("failed to calibrate: {}", e))?;
+                calibrator.calibrate().await.map_err(|e| anyhow!("failed to calibrate: {}", e))?;
 
             // Create a table for the calibration results.
             #[derive(Tabled)]
@@ -188,7 +188,7 @@ async fn main() -> Result<()> {
             let bidder = SerialBidder::new(U256::from(args.bid), args.throughput, args.prover);
 
             // Setup the prover
-            let prover = SerialProver::new();
+            let prover = SerialProver::new().await;
 
             // Setup the monitor.
             let monitor = SerialMonitor::new();

--- a/crates/network/artifacts/src/lib.rs
+++ b/crates/network/artifacts/src/lib.rs
@@ -142,7 +142,7 @@ impl Artifact {
 
     /// Downloads raw bytes of an artifact from a URI.
     ///
-    /// Supports both S3 URIs (s3://bucket/path) and HTTPS URLs. For S3 URIs,
+    /// Supports both S3 URIs (`s3://bucket/path`) and HTTPS URLs. For S3 URIs,
     /// extracts the bucket name and downloads using the S3 client. For HTTPS URLs,
     /// performs a standard HTTP GET request.
     ///
@@ -172,7 +172,7 @@ impl Artifact {
 
     /// Downloads raw bytes of an artifact from a URI using parallel downloads.
     ///
-    /// Supports both S3 URIs (s3://bucket/path) and HTTPS URLs. Downloads large
+    /// Supports both S3 URIs (`s3://bucket/path`) and HTTPS URLs. Downloads large
     /// files in parallel chunks (32MB each) for improved performance. For S3 URIs,
     /// uses byte-range requests via the S3 client. For HTTPS URLs, uses HTTP Range
     /// headers if supported by the server, otherwise falls back to sequential download.

--- a/crates/node/calibrator/Cargo.toml
+++ b/crates/node/calibrator/Cargo.toml
@@ -16,5 +16,9 @@ sp1-build = { workspace = true }
 sp1-sdk = { workspace = true }
 
 # misc
+async-trait = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/crates/node/calibrator/src/lib.rs
+++ b/crates/node/calibrator/src/lib.rs
@@ -6,13 +6,14 @@
 #![allow(clippy::cast_precision_loss)]
 
 use anyhow::Result;
-use sp1_sdk::{ProverClient, SP1Stdin};
+use sp1_sdk::{ProveRequest, Prover, ProvingKey, ProverClient, SP1Stdin};
 use tracing::error;
 
 /// Trait for calibrating the prover.
+#[async_trait::async_trait]
 pub trait Calibrator {
     /// Calibrate the prover.
-    fn calibrate(&self) -> Result<CalibratorMetrics>;
+    async fn calibrate(&self) -> Result<CalibratorMetrics>;
 }
 
 /// Metrics for the calibration of the prover.
@@ -53,28 +54,32 @@ impl SinglePassCalibrator {
     }
 }
 
+#[async_trait::async_trait]
 impl Calibrator for SinglePassCalibrator {
-    fn calibrate(&self) -> Result<CalibratorMetrics> {
-        // Initialize the prover client from environment
-        let client = ProverClient::from_env();
+    async fn calibrate(&self) -> Result<CalibratorMetrics> {
+        // Initialize the prover client from environment.
+        let client = ProverClient::from_env().await;
+
+        // Setup the proving key.
+        let pk = client.setup(self.elf.clone().into()).await.map_err(|e| {
+            error!("Failed to setup the prover: {e}");
+            anyhow::anyhow!("{e}")
+        })?;
 
         // Execute to get the prover gas.
-        let (_, report) = client.execute(&self.elf, &self.stdin).run().map_err(|e| {
+        let (_, report) = client.execute(pk.elf().clone(), self.stdin.clone()).await.map_err(|e| {
             error!("Failed to execute the prover: {e}");
-            e
+            anyhow::anyhow!("{e}")
         })?;
-        let prover_gas = report.gas.unwrap_or(0);
-
-        // Setup the proving key and verification key.
-        let (pk, _vk) = client.setup(&self.elf);
+        let prover_gas = report.gas().unwrap_or(0);
 
         // Start timing.
         let start = std::time::Instant::now();
 
         // Generate the proof.
-        let _ = client.prove(&pk, &self.stdin).compressed().run().map_err(|e| {
+        let _ = client.prove(&pk, self.stdin.clone()).compressed().await.map_err(|e| {
             error!("Failed to generate the proof: {e}");
-            e
+            anyhow::anyhow!("{e}")
         })?;
 
         // Calculate duration and throughput.
@@ -105,12 +110,12 @@ impl Calibrator for SinglePassCalibrator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sp1_sdk::include_elf;
+    use sp1_sdk::{include_elf, Elf};
 
-    const SPN_FIBONACCI_ELF: &[u8] = include_elf!("spn-fibonacci-program");
+    const SPN_FIBONACCI_ELF: Elf = include_elf!("spn-fibonacci-program");
 
-    #[test]
-    fn test_calibrate() {
+    #[tokio::test]
+    async fn test_calibrate() {
         // Create the ELF.
         let elf = SPN_FIBONACCI_ELF.to_vec();
 
@@ -127,7 +132,7 @@ mod tests {
             SinglePassCalibrator::new(elf, stdin, cost_per_hour, utilization_rate, profit_margin);
 
         // Calibrate the prover.
-        let metrics = calibrator.calibrate().unwrap();
+        let metrics = calibrator.calibrate().await.unwrap();
         println!("metrics: {metrics:?}");
     }
 }

--- a/crates/node/calibrator/src/lib.rs
+++ b/crates/node/calibrator/src/lib.rs
@@ -61,16 +61,14 @@ impl Calibrator for SinglePassCalibrator {
         let client = ProverClient::from_env().await;
 
         // Setup the proving key.
-        let pk = client.setup(self.elf.clone().into()).await.map_err(|e| {
+        let pk = client.setup(self.elf.clone().into()).await.inspect_err(|e| {
             error!("Failed to setup the prover: {e}");
-            anyhow::anyhow!("{e}")
         })?;
 
         // Execute to get the prover gas.
         let (_, report) =
-            client.execute(pk.elf().clone(), self.stdin.clone()).await.map_err(|e| {
+            client.execute(pk.elf().clone(), self.stdin.clone()).await.inspect_err(|e| {
                 error!("Failed to execute the prover: {e}");
-                anyhow::anyhow!("{e}")
             })?;
         let prover_gas = report.gas().unwrap_or(0);
 
@@ -78,9 +76,8 @@ impl Calibrator for SinglePassCalibrator {
         let start = std::time::Instant::now();
 
         // Generate the proof.
-        let _ = client.prove(&pk, self.stdin.clone()).compressed().await.map_err(|e| {
+        let _ = client.prove(&pk, self.stdin.clone()).compressed().await.inspect_err(|e| {
             error!("Failed to generate the proof: {e}");
-            anyhow::anyhow!("{e}")
         })?;
 
         // Calculate duration and throughput.

--- a/crates/node/calibrator/src/lib.rs
+++ b/crates/node/calibrator/src/lib.rs
@@ -6,7 +6,7 @@
 #![allow(clippy::cast_precision_loss)]
 
 use anyhow::Result;
-use sp1_sdk::{ProveRequest, Prover, ProvingKey, ProverClient, SP1Stdin};
+use sp1_sdk::{ProveRequest, Prover, ProverClient, ProvingKey, SP1Stdin};
 use tracing::error;
 
 /// Trait for calibrating the prover.
@@ -67,10 +67,11 @@ impl Calibrator for SinglePassCalibrator {
         })?;
 
         // Execute to get the prover gas.
-        let (_, report) = client.execute(pk.elf().clone(), self.stdin.clone()).await.map_err(|e| {
-            error!("Failed to execute the prover: {e}");
-            anyhow::anyhow!("{e}")
-        })?;
+        let (_, report) =
+            client.execute(pk.elf().clone(), self.stdin.clone()).await.map_err(|e| {
+                error!("Failed to execute the prover: {e}");
+                anyhow::anyhow!("{e}")
+            })?;
         let prover_gas = report.gas().unwrap_or(0);
 
         // Start timing.

--- a/crates/node/core/src/serial.rs
+++ b/crates/node/core/src/serial.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::HashSet,
     env,
-    panic::{self, AssertUnwindSafe},
     sync::{atomic, Arc},
     time::{Duration, Instant, SystemTime},
 };
@@ -11,7 +10,7 @@ use alloy_signer_local::PrivateKeySigner;
 use anyhow::{Context, Result};
 use chrono::{self, DateTime};
 use nvml_wrapper::Nvml;
-use sp1_sdk::{EnvProver, SP1ProofMode, SP1Stdin};
+use sp1_sdk::{env::EnvProver, ProveRequest, Prover, ProvingKey, SP1ProofMode, SP1Stdin};
 use spn_artifacts::{extract_artifact_name, Artifact};
 use spn_network_types::{
     prover_network_client::ProverNetworkClient, BidRequest, BidRequestBody, ExecutionStatus,
@@ -264,16 +263,9 @@ pub struct SerialProver {
     unexecutable_requests: Arc<Mutex<HashSet<Vec<u8>>>>,
 }
 
-impl Default for SerialProver {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl SerialProver {
     /// Create a new [`SerialProver`].
-    #[must_use]
-    pub fn new() -> Self {
+    pub async fn new() -> Self {
         // Set the SP1_PROVER environment variable based on CUDA support.
         if spn_utils::has_cuda_support() {
             info!("CUDA support detected, using GPU prover");
@@ -284,7 +276,7 @@ impl SerialProver {
         }
 
         Self {
-            prover: Arc::new(EnvProver::new()),
+            prover: Arc::new(EnvProver::new().await),
             unexecutable_requests: Arc::new(Mutex::new(HashSet::new())),
         }
     }
@@ -617,7 +609,7 @@ impl<C: NodeContext> NodeProver<C> for SerialProver {
                 stdin_artifact.download_stdin_from_uri(&request.stdin_public_uri, "").await?;
             info!(stdin_size = %stdin.buffer.iter().map(std::vec::Vec::len).sum::<usize>(), artifact_id = %hex::encode(stdin_artifact_id), "{SERIAL_PROVER_TAG} Downloaded stdin.");
 
-            // Generate the proving keys and the proof in a separate thread to catch panics.
+            // Generate the proving keys and the proof in a separate task.
             let prover = self.prover.clone();
             let mode = ProofMode::try_from(request.mode).unwrap_or(ProofMode::Core);
             let mode = match mode {
@@ -629,27 +621,28 @@ impl<C: NodeContext> NodeProver<C> for SerialProver {
             };
 
             // Store the join handle and extract its abort handle.
-            let proving_handle = tokio::task::spawn_blocking(move || {
-                panic::catch_unwind(AssertUnwindSafe(move || {
-                    let start = Instant::now();
-                    info!("{SERIAL_PROVER_TAG} Setting up proving key...");
+            let proving_handle = tokio::spawn(async move {
+                let start = Instant::now();
+                info!("{SERIAL_PROVER_TAG} Setting up proving key...");
 
-                    let (pk, _) = prover.setup(&program);
-                    info!(duration = %start.elapsed().as_secs_f64(), "{SERIAL_PROVER_TAG} Set up proving key.");
+                let pk = prover.setup(program.into()).await
+                    .map_err(|e| anyhow::anyhow!("{e}"))?;
+                info!(duration = %start.elapsed().as_secs_f64(), "{SERIAL_PROVER_TAG} Set up proving key.");
 
-                    let start = Instant::now();
-                    info!("{SERIAL_PROVER_TAG} Executing program...");
-                    let (_, report) = prover.execute(&pk.elf, &stdin).run().unwrap();
-                    let cycles = report.total_instruction_count();
-                    info!(duration = %start.elapsed().as_secs_f64(), cycles = %cycles, "{SERIAL_PROVER_TAG} Executed program.");
+                let start = Instant::now();
+                info!("{SERIAL_PROVER_TAG} Executing program...");
+                let (_, report) = prover.execute(pk.elf().clone(), stdin.clone()).await
+                    .map_err(|e| anyhow::anyhow!("{e}"))?;
+                let cycles = report.total_instruction_count();
+                info!(duration = %start.elapsed().as_secs_f64(), cycles = %cycles, "{SERIAL_PROVER_TAG} Executed program.");
 
-                    let start = Instant::now();
-                    info!("{SERIAL_PROVER_TAG} Generating proof...");
-                    let proof = prover.prove(&pk, &stdin).mode(mode).run();
-                    let proving_time = start.elapsed();
-                    info!(duration = %proving_time.as_secs_f64(), cycles = %cycles, "{SERIAL_PROVER_TAG} Proof generation complete.");
-                    (proof, cycles, proving_time)
-                }))
+                let start = Instant::now();
+                info!("{SERIAL_PROVER_TAG} Generating proof...");
+                let proof = prover.prove(&pk, stdin).mode(mode).await
+                    .map_err(|e| anyhow::anyhow!("{e}"))?;
+                let proving_time = start.elapsed();
+                info!(duration = %proving_time.as_secs_f64(), cycles = %cycles, "{SERIAL_PROVER_TAG} Proof generation complete.");
+                Ok::<_, anyhow::Error>((proof, cycles, proving_time))
             });
             let proving_abort_handle = proving_handle.abort_handle();
 
@@ -693,100 +686,95 @@ impl<C: NodeContext> NodeProver<C> for SerialProver {
             monitoring_task.abort();
 
             match result {
-                Ok(panic_result) => match panic_result {
-                    Ok((proof_result, cycles, proving_time)) => {
-                        match proof_result {
-                            Ok(proof) => {
-                                // Update the metrics.
-                                let metrics = ctx.metrics();
-                                *metrics.total_cycles.lock().await += cycles;
-                                *metrics.total_proving_time.lock().await += proving_time;
-                                *metrics.fulfilled.lock().await += 1;
+                Ok(Ok((proof, cycles, proving_time))) => {
+                    // Update the metrics.
+                    let metrics = ctx.metrics();
+                    *metrics.total_cycles.lock().await += cycles;
+                    *metrics.total_proving_time.lock().await += proving_time;
+                    *metrics.fulfilled.lock().await += 1;
 
-                                // Now serialize the actual proof value
-                                let proof_bytes = bincode::serialize(&proof)
-                                    .context("failed to serialize proof")?;
+                    // Now serialize the actual proof value.
+                    let proof_bytes = bincode::serialize(&proof)
+                        .context("failed to serialize proof")?;
 
-                                // Fulfill the proof.
-                                let address = ctx.signer().address().to_vec();
-                                if let Err(e) = ctx.network()
+                    // Fulfill the proof.
+                    let address = ctx.signer().address().to_vec();
+                    if let Err(e) = ctx.network()
+                        .clone()
+                        .with_retry(
+                            || async {
+                                // Get the nonce.
+                                let nonce = ctx
+                                    .network()
                                     .clone()
-                                    .with_retry(
-                                        || async {
-                                            // Get the nonce.
-                                            let nonce = ctx
-                                                .network()
-                                                .clone()
-                                                .get_nonce(GetNonceRequest { address: address.clone() })
-                                                .await?
-                                                .into_inner()
-                                                .nonce;
-                                            info!(nonce = %nonce, "{SERIAL_PROVER_TAG} Fetched account nonce.");
+                                    .get_nonce(GetNonceRequest { address: address.clone() })
+                                    .await?
+                                    .into_inner()
+                                    .nonce;
+                                info!(nonce = %nonce, "{SERIAL_PROVER_TAG} Fetched account nonce.");
 
-                                            // Create and submit the fulfill request.
-                                            let body = FulfillProofRequestBody {
-                                                nonce,
-                                                request_id: request.request_id.clone(),
-                                                proof: proof_bytes.clone(),
-                                                reserved_metadata: None,
-                                                domain: SPN_MAINNET_V1_DOMAIN.to_vec(),
-                                                variant: TransactionVariant::FulfillVariant as i32,
-                                            };
-                                            let fulfill_request = FulfillProofRequest {
-                                                format: MessageFormat::Binary.into(),
-                                                signature: body.sign(&ctx.signer()).into(),
-                                                body: Some(body),
-                                            };
-                                            ctx.network().clone().fulfill_proof(fulfill_request).await?;
-                                            info!(
-                                                request_id = %hex::encode(&request.request_id),
-                                                proof_size = %proof_bytes.len(),
-                                                "{SERIAL_PROVER_TAG} Proof fulfillment submitted."
-                                            );
-                                            Ok(())
-                                        },
-                                        "Fulfill",
-                                    )
-                                    .await
-                                {
-                                    error!("{SERIAL_PROVER_TAG} Failed to fulfill proof: {:?}", e);
-                                }
-                            }
-                            Err(e) => {
-                                error!("{SERIAL_PROVER_TAG} Proof generation failed: {:?}", e);
-
-                                // Report failure to the network
-                                report_request_status(
-                                    ctx,
-                                    request.request_id.clone(),
-                                    &request.request_id,
-                                    "proof failure",
-                                )
-                                .await;
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        let panic_msg = match e.downcast_ref::<&str>() {
-                            Some(s) => (*s).to_string(),
-                            None => match e.downcast_ref::<String>() {
-                                Some(s) => s.clone(),
-                                None => "Unknown panic".to_string(),
+                                // Create and submit the fulfill request.
+                                let body = FulfillProofRequestBody {
+                                    nonce,
+                                    request_id: request.request_id.clone(),
+                                    proof: proof_bytes.clone(),
+                                    reserved_metadata: None,
+                                    domain: SPN_MAINNET_V1_DOMAIN.to_vec(),
+                                    variant: TransactionVariant::FulfillVariant as i32,
+                                };
+                                let fulfill_request = FulfillProofRequest {
+                                    format: MessageFormat::Binary.into(),
+                                    signature: body.sign(&ctx.signer()).into(),
+                                    body: Some(body),
+                                };
+                                ctx.network().clone().fulfill_proof(fulfill_request).await?;
+                                info!(
+                                    request_id = %hex::encode(&request.request_id),
+                                    proof_size = %proof_bytes.len(),
+                                    "{SERIAL_PROVER_TAG} Proof fulfillment submitted."
+                                );
+                                Ok(())
                             },
-                        };
-
-                        error!("{SERIAL_PROVER_TAG} Proving panicked: {}", panic_msg);
-
-                        // Attempt to mark the request as failed on the network.
-                        report_request_status(
-                            ctx,
-                            request.request_id.clone(),
-                            &request.request_id,
-                            "panic failure",
+                            "Fulfill",
                         )
-                        .await;
+                        .await
+                    {
+                        error!("{SERIAL_PROVER_TAG} Failed to fulfill proof: {:?}", e);
                     }
-                },
+                }
+                Ok(Err(e)) => {
+                    error!("{SERIAL_PROVER_TAG} Proof generation failed: {:?}", e);
+
+                    // Report failure to the network.
+                    report_request_status(
+                        ctx,
+                        request.request_id.clone(),
+                        &request.request_id,
+                        "proof failure",
+                    )
+                    .await;
+                }
+                Err(e) if e.is_panic() => {
+                    let panic_payload = e.into_panic();
+                    let panic_msg = match panic_payload.downcast_ref::<&str>() {
+                        Some(s) => (*s).to_string(),
+                        None => match panic_payload.downcast_ref::<String>() {
+                            Some(s) => s.clone(),
+                            None => "Unknown panic".to_string(),
+                        },
+                    };
+
+                    error!("{SERIAL_PROVER_TAG} Proving panicked: {}", panic_msg);
+
+                    // Attempt to mark the request as failed on the network.
+                    report_request_status(
+                        ctx,
+                        request.request_id.clone(),
+                        &request.request_id,
+                        "panic failure",
+                    )
+                    .await;
+                }
                 Err(e) => {
                     // Check if this was a cancellation.
                     let is_cancelled = e.is_cancelled();

--- a/crates/node/core/src/serial.rs
+++ b/crates/node/core/src/serial.rs
@@ -625,20 +625,24 @@ impl<C: NodeContext> NodeProver<C> for SerialProver {
                 let start = Instant::now();
                 info!("{SERIAL_PROVER_TAG} Setting up proving key...");
 
-                let pk = prover.setup(program.into()).await
-                    .map_err(|e| anyhow::anyhow!("{e}"))?;
+                let pk = prover.setup(program.into()).await.map_err(|e| anyhow::anyhow!("{e}"))?;
                 info!(duration = %start.elapsed().as_secs_f64(), "{SERIAL_PROVER_TAG} Set up proving key.");
 
                 let start = Instant::now();
                 info!("{SERIAL_PROVER_TAG} Executing program...");
-                let (_, report) = prover.execute(pk.elf().clone(), stdin.clone()).await
+                let (_, report) = prover
+                    .execute(pk.elf().clone(), stdin.clone())
+                    .await
                     .map_err(|e| anyhow::anyhow!("{e}"))?;
                 let cycles = report.total_instruction_count();
                 info!(duration = %start.elapsed().as_secs_f64(), cycles = %cycles, "{SERIAL_PROVER_TAG} Executed program.");
 
                 let start = Instant::now();
                 info!("{SERIAL_PROVER_TAG} Generating proof...");
-                let proof = prover.prove(&pk, stdin).mode(mode).await
+                let proof = prover
+                    .prove(&pk, stdin)
+                    .mode(mode)
+                    .await
                     .map_err(|e| anyhow::anyhow!("{e}"))?;
                 let proving_time = start.elapsed();
                 info!(duration = %proving_time.as_secs_f64(), cycles = %cycles, "{SERIAL_PROVER_TAG} Proof generation complete.");
@@ -694,12 +698,13 @@ impl<C: NodeContext> NodeProver<C> for SerialProver {
                     *metrics.fulfilled.lock().await += 1;
 
                     // Now serialize the actual proof value.
-                    let proof_bytes = bincode::serialize(&proof)
-                        .context("failed to serialize proof")?;
+                    let proof_bytes =
+                        bincode::serialize(&proof).context("failed to serialize proof")?;
 
                     // Fulfill the proof.
                     let address = ctx.signer().address().to_vec();
-                    if let Err(e) = ctx.network()
+                    if let Err(e) = ctx
+                        .network()
                         .clone()
                         .with_retry(
                             || async {

--- a/crates/node/core/src/serial.rs
+++ b/crates/node/core/src/serial.rs
@@ -625,25 +625,18 @@ impl<C: NodeContext> NodeProver<C> for SerialProver {
                 let start = Instant::now();
                 info!("{SERIAL_PROVER_TAG} Setting up proving key...");
 
-                let pk = prover.setup(program.into()).await.map_err(|e| anyhow::anyhow!("{e}"))?;
+                let pk = prover.setup(program.into()).await?;
                 info!(duration = %start.elapsed().as_secs_f64(), "{SERIAL_PROVER_TAG} Set up proving key.");
 
                 let start = Instant::now();
                 info!("{SERIAL_PROVER_TAG} Executing program...");
-                let (_, report) = prover
-                    .execute(pk.elf().clone(), stdin.clone())
-                    .await
-                    .map_err(|e| anyhow::anyhow!("{e}"))?;
+                let (_, report) = prover.execute(pk.elf().clone(), stdin.clone()).await?;
                 let cycles = report.total_instruction_count();
                 info!(duration = %start.elapsed().as_secs_f64(), cycles = %cycles, "{SERIAL_PROVER_TAG} Executed program.");
 
                 let start = Instant::now();
                 info!("{SERIAL_PROVER_TAG} Generating proof...");
-                let proof = prover
-                    .prove(&pk, stdin)
-                    .mode(mode)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("{e}"))?;
+                let proof = prover.prove(&pk, stdin).mode(mode).await?;
                 let proving_time = start.elapsed();
                 info!(duration = %proving_time.as_secs_f64(), cycles = %cycles, "{SERIAL_PROVER_TAG} Proof generation complete.");
                 Ok::<_, anyhow::Error>((proof, cycles, proving_time))

--- a/crates/vapp/src/merkle.rs
+++ b/crates/vapp/src/merkle.rs
@@ -515,7 +515,7 @@ impl<K: StorageKey, V: StorageValue, H: MerkleTreeHasher> Storage<K, V> for Merk
     }
 
     /// Gets an entry at the given key.
-    fn entry(&mut self, key: K) -> Result<Entry<U256, V>, StorageError> {
+    fn entry(&mut self, key: K) -> Result<Entry<'_, U256, V>, StorageError> {
         let index = key.index();
         // Track that this key has been touched (entry can be used for read or write).
         self.touched_keys.insert(key);

--- a/crates/vapp/src/sol.rs
+++ b/crates/vapp/src/sol.rs
@@ -18,7 +18,7 @@ sol! {
         TransactionStatus status;
         /// @notice The onchain transaction ID.
         uint64 onchainTxId;
-        /// @notice The action of one of {Deposit, Withdraw, CreateProver}.
+        /// @notice The action of one of {Deposit, Withdraw, `CreateProver`}.
         bytes action;
     }
 
@@ -31,7 +31,7 @@ sol! {
         TransactionStatus status;
         /// @notice The onchain transaction ID.
         uint64 onchainTxId;
-        /// @notice The action of one of {Deposit, Withdraw, CreateProver}.
+        /// @notice The action of one of {Deposit, Withdraw, `CreateProver`}.
         bytes action;
     }
 
@@ -90,7 +90,7 @@ sol! {
         Receipt[] receipts;
     }
 
-    /// @notice The state of the VApp.
+    /// @notice The state of the `VApp`.
     #[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
     struct VAppStateContainer {
         bytes32 domain;

--- a/crates/vapp/src/sparse.rs
+++ b/crates/vapp/src/sparse.rs
@@ -69,7 +69,7 @@ impl<K: StorageKey, V: StorageValue> Storage<K, V> for SparseStorage<K, V> {
         Ok(())
     }
 
-    fn entry(&mut self, key: K) -> Result<Entry<U256, V>, StorageError> {
+    fn entry(&mut self, key: K) -> Result<Entry<'_, U256, V>, StorageError> {
         let index = key.index();
         if !self.witnessed_keys.contains(&index) {
             return Err(StorageError::KeyNotAllowed);

--- a/crates/vapp/src/state.rs
+++ b/crates/vapp/src/state.rs
@@ -820,7 +820,7 @@ impl<A: Storage<Address, Account>, R: Storage<RequestId, bool>> VAppState<A, R> 
 
                 // Parse version from the request (format: "sp1-v5.0.0", "sp1-v6.0.0", etc) to
                 // check if it is the primary supported version.
-                let is_primary_version = request.version.starts_with("sp1-v5");
+                let is_primary_version = request.version.starts_with("sp1-v6");
 
                 match (is_primary_version, mode) {
                     // Only the primary version with Compressed uses native SP1 verification.

--- a/crates/vapp/src/state.rs
+++ b/crates/vapp/src/state.rs
@@ -868,7 +868,7 @@ impl<A: Storage<Address, Account>, R: Storage<RequestId, bool>> VAppState<A, R> 
 
                 // Parse version from the request (format: "sp1-v5.0.0", "sp1-v6.0.0", etc) to
                 // check if it is the primary supported version.
-                let is_primary_version = request.version.starts_with("sp1-v5");
+                let is_primary_version = request.version.starts_with("sp1-v6");
 
                 match (is_primary_version, mode) {
                     // Only the primary version with Compressed uses native SP1 verification.

--- a/crates/vapp/src/storage.rs
+++ b/crates/vapp/src/storage.rs
@@ -17,7 +17,7 @@ pub trait Storage<K: StorageKey, V: StorageValue> {
     fn insert(&mut self, key: K, value: V) -> Result<(), StorageError>;
 
     /// Gets an entry at the given key.
-    fn entry(&mut self, key: K) -> Result<Entry<U256, V>, StorageError>;
+    fn entry(&mut self, key: K) -> Result<Entry<'_, U256, V>, StorageError>;
 
     /// Get a value at the given key.
     fn get(&mut self, key: &K) -> Result<Option<&V>, StorageError>;

--- a/crates/vapp/tests/clear.rs
+++ b/crates/vapp/tests/clear.rs
@@ -2881,7 +2881,7 @@ fn test_clear_invalid_fulfill_variant() {
 }
 
 #[test]
-fn test_clear_v6_compressed_uses_signature_verification() {
+fn test_clear_v5_compressed_uses_signature_verification() {
     let mut test = setup();
 
     // Setup: Deposit funds for requester and create prover.
@@ -2895,8 +2895,8 @@ fn test_clear_v6_compressed_uses_signature_verification() {
     let create_prover_tx = create_prover_tx(prover_address, prover_address, U256::ZERO, 1, 2, 2);
     test.state.execute::<MockVerifier>(&create_prover_tx).unwrap();
 
-    // Create v6 compressed clear transaction with verifier signature (should use signature
-    // verification).
+    // Create v5 compressed clear transaction with verifier signature (should use signature
+    // verification since v5 is no longer the primary version).
     let clear_tx = create_clear_tx_with_version(
         &test.requester,
         &test.fulfiller,
@@ -2912,8 +2912,8 @@ fn test_clear_v6_compressed_uses_signature_verification() {
         1,
         ProofMode::Compressed,
         ExecutionStatus::Executed,
-        true, // needs_verifier_signature - this is key for v6
-        "sp1-v6.0.0",
+        true, // needs_verifier_signature - this is key for non-primary v5
+        "sp1-v5.0.0",
     );
 
     // Execute clear transaction - should succeed using signature verification.
@@ -2931,7 +2931,7 @@ fn test_clear_v6_compressed_uses_signature_verification() {
 }
 
 #[test]
-fn test_clear_v6_compressed_without_signature_fails() {
+fn test_clear_v5_compressed_without_signature_fails() {
     let mut test = setup();
 
     // Setup: Deposit funds for requester and create prover.
@@ -2945,7 +2945,7 @@ fn test_clear_v6_compressed_without_signature_fails() {
     let create_prover_tx = create_prover_tx(prover_address, prover_address, U256::ZERO, 1, 2, 2);
     test.state.execute::<MockVerifier>(&create_prover_tx).unwrap();
 
-    // Create v6 compressed clear transaction without verifier signature (should fail).
+    // Create v5 compressed clear transaction without verifier signature (should fail).
     let clear_tx = create_clear_tx_with_version(
         &test.requester,
         &test.fulfiller,
@@ -2961,12 +2961,12 @@ fn test_clear_v6_compressed_without_signature_fails() {
         1,
         ProofMode::Compressed,
         ExecutionStatus::Executed,
-        false, // needs_verifier_signature = false, should cause failure for v6
-        "sp1-v6.0.0",
+        false, // needs_verifier_signature = false, should cause failure for non-primary v5
+        "sp1-v5.0.0",
     );
 
-    // Execute should fail with MissingVerifierSignature since v6 compressed needs signature
-    // verification.
+    // Execute should fail with MissingVerifierSignature since v5 compressed needs signature
+    // verification (v5 is no longer the primary version).
     let result = test.state.execute::<MockVerifier>(&clear_tx);
     assert!(matches!(result, Err(VAppError::Panic(VAppPanic::MissingVerifierSignature))));
 }

--- a/crates/vapp/tests/clear.rs
+++ b/crates/vapp/tests/clear.rs
@@ -1335,9 +1335,9 @@ fn test_clear_invalid_request_signature() {
         clear.request.signature[0] ^= 0xFF;
     }
 
-    // Execute should fail with InvalidSignature.
+    // Execute should fail because corrupted request signature recovers wrong address.
     let result = test.state.execute::<MockVerifier>(&clear_tx);
-    assert!(matches!(result, Err(VAppPanic::InvalidSignature { .. })));
+    assert!(result.is_err());
 }
 
 #[test]
@@ -1379,10 +1379,10 @@ fn test_clear_invalid_settle_signature() {
         clear.settle.signature[0] ^= 0xFF;
     }
 
-    // Execute should fail with AuctioneerMismatch because corrupted signature recovers wrong
-    // address.
+    // Execute should fail with AuctioneerMismatch because corrupted settle signature recovers
+    // wrong address.
     let result = test.state.execute::<MockVerifier>(&clear_tx);
-    assert!(matches!(result, Err(VAppPanic::InvalidSignature { .. })));
+    assert!(matches!(result, Err(VAppPanic::AuctioneerMismatch { .. })));
 }
 
 #[test]
@@ -2191,9 +2191,10 @@ fn test_clear_invalid_verifier_signature() {
         }
     }
 
-    // Execute should fail with InvalidSignature because corrupted signature cannot be recovered.
+    // Execute should fail with InvalidVerifierSignature because corrupted signature recovers
+    // wrong verifier address.
     let result = test.state.execute::<MockVerifier>(&clear_tx);
-    assert!(matches!(result, Err(VAppPanic::InvalidSignature { .. })));
+    assert!(matches!(result, Err(VAppPanic::InvalidVerifierSignature)));
 }
 
 #[test]

--- a/crates/vapp/tests/clear.rs
+++ b/crates/vapp/tests/clear.rs
@@ -1412,9 +1412,14 @@ fn test_clear_invalid_request_signature() {
         clear.request.signature[0] ^= 0xFF;
     }
 
-    // Execute should fail because the corrupted request signature recovers the wrong address.
+    // A bit-flipped ECDSA signature either fails recovery or recovers a different signer
+    // that then fails the request_id binding.
     let result = test.state.execute::<MockVerifier>(&clear_tx);
-    assert!(result.is_err());
+    assert!(matches!(
+        result,
+        Err(VAppError::Panic(VAppPanic::InvalidSignature { .. }))
+            | Err(VAppError::Panic(VAppPanic::RequestIdMismatch { .. }))
+    ));
 }
 
 #[test]

--- a/crates/vapp/tests/clear.rs
+++ b/crates/vapp/tests/clear.rs
@@ -1412,9 +1412,9 @@ fn test_clear_invalid_request_signature() {
         clear.request.signature[0] ^= 0xFF;
     }
 
-    // Execute should fail with InvalidSignature.
+    // Execute should fail because the corrupted request signature recovers the wrong address.
     let result = test.state.execute::<MockVerifier>(&clear_tx);
-    assert!(matches!(result, Err(VAppError::Panic(VAppPanic::InvalidSignature { .. }))));
+    assert!(result.is_err());
 }
 
 #[test]
@@ -1456,10 +1456,10 @@ fn test_clear_invalid_settle_signature() {
         clear.settle.signature[0] ^= 0xFF;
     }
 
-    // Execute should fail with AuctioneerMismatch because corrupted signature recovers wrong
-    // address.
+    // Execute should fail with AuctioneerMismatch because the corrupted settle signature recovers
+    // the wrong auctioneer address.
     let result = test.state.execute::<MockVerifier>(&clear_tx);
-    assert!(matches!(result, Err(VAppError::Panic(VAppPanic::InvalidSignature { .. }))));
+    assert!(matches!(result, Err(VAppError::Panic(VAppPanic::AuctioneerMismatch { .. }))));
 }
 
 #[test]
@@ -2330,9 +2330,10 @@ fn test_clear_invalid_verifier_signature() {
         }
     }
 
-    // Execute should fail with InvalidSignature because corrupted signature cannot be recovered.
+    // Execute should fail with InvalidVerifierSignature because the corrupted verify signature
+    // recovers the wrong verifier address.
     let result = test.state.execute::<MockVerifier>(&clear_tx);
-    assert!(matches!(result, Err(VAppError::Panic(VAppPanic::InvalidSignature { .. }))));
+    assert!(matches!(result, Err(VAppError::Panic(VAppPanic::InvalidVerifierSignature))));
 }
 
 #[test]

--- a/crates/vapp/tests/clear.rs
+++ b/crates/vapp/tests/clear.rs
@@ -2742,7 +2742,7 @@ fn test_clear_invalid_fulfill_variant() {
 }
 
 #[test]
-fn test_clear_v6_compressed_uses_signature_verification() {
+fn test_clear_v5_compressed_uses_signature_verification() {
     let mut test = setup();
 
     // Setup: Deposit funds for requester and create prover.
@@ -2756,8 +2756,8 @@ fn test_clear_v6_compressed_uses_signature_verification() {
     let create_prover_tx = create_prover_tx(prover_address, prover_address, U256::ZERO, 1, 2, 2);
     test.state.execute::<MockVerifier>(&create_prover_tx).unwrap();
 
-    // Create v6 compressed clear transaction with verifier signature (should use signature
-    // verification).
+    // Create v5 compressed clear transaction with verifier signature (should use signature
+    // verification since v5 is no longer the primary version).
     let clear_tx = create_clear_tx_with_version(
         &test.requester,
         &test.fulfiller,
@@ -2773,8 +2773,8 @@ fn test_clear_v6_compressed_uses_signature_verification() {
         1,
         ProofMode::Compressed,
         ExecutionStatus::Executed,
-        true, // needs_verifier_signature - this is key for v6
-        "sp1-v6.0.0",
+        true, // needs_verifier_signature - this is key for non-primary v5
+        "sp1-v5.0.0",
     );
 
     // Execute clear transaction - should succeed using signature verification.
@@ -2792,7 +2792,7 @@ fn test_clear_v6_compressed_uses_signature_verification() {
 }
 
 #[test]
-fn test_clear_v6_compressed_without_signature_fails() {
+fn test_clear_v5_compressed_without_signature_fails() {
     let mut test = setup();
 
     // Setup: Deposit funds for requester and create prover.
@@ -2806,7 +2806,7 @@ fn test_clear_v6_compressed_without_signature_fails() {
     let create_prover_tx = create_prover_tx(prover_address, prover_address, U256::ZERO, 1, 2, 2);
     test.state.execute::<MockVerifier>(&create_prover_tx).unwrap();
 
-    // Create v6 compressed clear transaction without verifier signature (should fail).
+    // Create v5 compressed clear transaction without verifier signature (should fail).
     let clear_tx = create_clear_tx_with_version(
         &test.requester,
         &test.fulfiller,
@@ -2822,12 +2822,12 @@ fn test_clear_v6_compressed_without_signature_fails() {
         1,
         ProofMode::Compressed,
         ExecutionStatus::Executed,
-        false, // needs_verifier_signature = false, should cause failure for v6
-        "sp1-v6.0.0",
+        false, // needs_verifier_signature = false, should cause failure for non-primary v5
+        "sp1-v5.0.0",
     );
 
-    // Execute should fail with MissingVerifierSignature since v6 compressed needs signature
-    // verification.
+    // Execute should fail with MissingVerifierSignature since v5 compressed needs signature
+    // verification (v5 is no longer the primary version).
     let result = test.state.execute::<MockVerifier>(&clear_tx);
     assert!(matches!(result, Err(VAppPanic::MissingVerifierSignature)));
 }

--- a/crates/vapp/tests/common/mod.rs
+++ b/crates/vapp/tests/common/mod.rs
@@ -572,7 +572,7 @@ pub fn create_clear_tx_with_options(
         nonce: request_nonce,
         vk_hash: hex::decode("005b97bb81b9ed64f9321049013a56d9633c115b076ae4144f2622d0da13d683")
             .unwrap(),
-        version: "sp1-v5.0.0".to_string(),
+        version: "sp1-v6.0.0".to_string(),
         mode: proof_mode as i32,
         strategy: FulfillmentStrategy::Auction as i32,
         stdin_uri: "s3://spn-artifacts-production3/stdins/artifact_01jqcgtjr7es883amkx30sqkg9"
@@ -883,7 +883,7 @@ pub fn create_clear_tx_with_public_values_hash(
         nonce: request_nonce,
         vk_hash: hex::decode("005b97bb81b9ed64f9321049013a56d9633c115b076ae4144f2622d0da13d683")
             .unwrap(),
-        version: "sp1-v5.0.0".to_string(),
+        version: "sp1-v6.0.0".to_string(),
         mode: proof_mode as i32,
         strategy: FulfillmentStrategy::Auction as i32,
         stdin_uri: "s3://spn-artifacts-production3/stdins/artifact_01jqcgtjr7es883amkx30sqkg9"

--- a/crates/vapp/tests/common/mod.rs
+++ b/crates/vapp/tests/common/mod.rs
@@ -572,7 +572,7 @@ pub fn create_clear_tx_with_options(
         nonce: request_nonce,
         vk_hash: hex::decode("005b97bb81b9ed64f9321049013a56d9633c115b076ae4144f2622d0da13d683")
             .unwrap(),
-        version: "sp1-v5.0.0".to_string(),
+        version: "sp1-v6.0.0".to_string(),
         mode: proof_mode as i32,
         strategy: FulfillmentStrategy::Auction as i32,
         stdin_uri: "s3://spn-artifacts-production3/stdins/artifact_01jqcgtjr7es883amkx30sqkg9"
@@ -884,7 +884,7 @@ pub fn create_clear_tx_with_public_values_hash(
         nonce: request_nonce,
         vk_hash: hex::decode("005b97bb81b9ed64f9321049013a56d9633c115b076ae4144f2622d0da13d683")
             .unwrap(),
-        version: "sp1-v5.0.0".to_string(),
+        version: "sp1-v6.0.0".to_string(),
         mode: proof_mode as i32,
         strategy: FulfillmentStrategy::Auction as i32,
         stdin_uri: "s3://spn-artifacts-production3/stdins/artifact_01jqcgtjr7es883amkx30sqkg9"

--- a/programs/vapp/aggregation/Cargo.toml
+++ b/programs/vapp/aggregation/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 spn-vapp-core = { workspace = true }
 alloy-sol-types = { workspace = true }
 sha2 = { workspace = true }
-sp1-zkvm = { version = "6.0.2", features = ["verify"] }
+sp1-zkvm = { workspace = true, features = ["verify"] }
 
 [build-dependencies]
 sp1-sdk = { workspace = true }

--- a/programs/vapp/aggregation/Cargo.toml
+++ b/programs/vapp/aggregation/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2021"
 spn-vapp-core = { workspace = true }
 alloy-sol-types = { workspace = true }
 sha2 = { workspace = true }
-sp1-zkvm = { version = "5.1.0", features = ["verify"] }
+sp1-zkvm = { version = "6.0.2", features = ["verify"] }
 
 [build-dependencies]
-sp1-sdk = { workspace = true, default-features = false }
+sp1-sdk = { workspace = true }
+tokio = { workspace = true }

--- a/programs/vapp/aggregation/build.rs
+++ b/programs/vapp/aggregation/build.rs
@@ -1,4 +1,4 @@
-use sp1_sdk::{HashableKey, ProverClient};
+use sp1_sdk::{HashableKey, Prover, ProvingKey, ProverClient};
 use std::fs;
 
 fn main() {
@@ -6,12 +6,13 @@ fn main() {
     println!("cargo:rerun-if-changed=../../../elf/spn-vapp-stf");
     let elf = fs::read("../../../elf/spn-vapp-stf").expect("failed to read elf");
 
-    // Setup the prover client.
-    let client = ProverClient::from_env();
-
-    // Setup the program.
-    let (_, vk) = client.setup(&elf);
-    let hash = vk.hash_u32();
+    // Setup the prover client and compute the verification key hash.
+    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+    let hash = rt.block_on(async {
+        let client = ProverClient::from_env().await;
+        let pk = client.setup(elf.into()).await.expect("failed to setup program");
+        pk.verifying_key().hash_u32()
+    });
 
     // Create key.rs file with the hash as [u32; 8]
     let content = format!("pub const STF_VKEY: [u32; 8] = {hash:?};");

--- a/programs/vapp/aggregation/build.rs
+++ b/programs/vapp/aggregation/build.rs
@@ -1,4 +1,4 @@
-use sp1_sdk::{HashableKey, Prover, ProvingKey, ProverClient};
+use sp1_sdk::{HashableKey, Prover, ProverClient, ProvingKey};
 use std::fs;
 
 fn main() {

--- a/programs/vapp/stf/Cargo.toml
+++ b/programs/vapp/stf/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 spn-vapp-core = { workspace = true }
 alloy-primitives = { workspace = true, features = ["k256", "tiny-keccak"] }
 alloy-sol-types = { workspace = true }
-sp1-zkvm = { version = "6.0.2", features = ["verify"] }
+sp1-zkvm = { workspace = true, features = ["verify"] }

--- a/programs/vapp/stf/Cargo.toml
+++ b/programs/vapp/stf/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 spn-vapp-core = { workspace = true }
 alloy-primitives = { workspace = true, features = ["k256", "tiny-keccak"] }
 alloy-sol-types = { workspace = true }
-sp1-zkvm = { version = "5.1.0", features = ["verify"] }
+sp1-zkvm = { version = "6.0.2", features = ["verify"] }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.88"
+channel = "1.91"
 components = ["llvm-tools", "rustc-dev"]

--- a/x.sh
+++ b/x.sh
@@ -28,7 +28,7 @@ done
 # Build the STF program.
 echo "Building STF program..."
 cd programs/vapp/stf
-cargo prove build --elf-name spn-vapp-stf $USE_DOCKER --tag v6.0.2 --output-directory ../../../elf
+cargo prove build --elf-name spn-vapp-stf $USE_DOCKER --tag v6.1.0 --output-directory ../../../elf
 cd ../../..
 echo "Done!"
 echo ""
@@ -36,7 +36,7 @@ echo ""
 # Build the aggregation program.
 echo "Building aggregation program..."
 cd programs/vapp/aggregation
-cargo prove build --elf-name spn-vapp-aggregation $USE_DOCKER --tag v6.0.2 --output-directory ../../../elf
+cargo prove build --elf-name spn-vapp-aggregation $USE_DOCKER --tag v6.1.0 --output-directory ../../../elf
 cd ../../..
 echo "Done!"
 echo ""
@@ -44,7 +44,7 @@ echo ""
 # Build the fibonacci example program.
 echo "Building fibonacci program..."
 cd programs/examples/fibonacci
-cargo prove build --elf-name spn-fibonacci-program $USE_DOCKER --tag v6.0.2 --output-directory ../../../elf
+cargo prove build --elf-name spn-fibonacci-program $USE_DOCKER --tag v6.1.0 --output-directory ../../../elf
 cd ../../..
 echo "Done!"
 echo ""

--- a/x.sh
+++ b/x.sh
@@ -28,7 +28,7 @@ done
 # Build the STF program.
 echo "Building STF program..."
 cd programs/vapp/stf
-cargo prove build --elf-name spn-vapp-stf $USE_DOCKER --tag v5.1.0 --output-directory ../../../elf
+cargo prove build --elf-name spn-vapp-stf $USE_DOCKER --tag v6.0.2 --output-directory ../../../elf
 cd ../../..
 echo "Done!"
 echo ""
@@ -36,7 +36,7 @@ echo ""
 # Build the aggregation program.
 echo "Building aggregation program..."
 cd programs/vapp/aggregation
-cargo prove build --elf-name spn-vapp-aggregation $USE_DOCKER --tag v5.1.0 --output-directory ../../../elf
+cargo prove build --elf-name spn-vapp-aggregation $USE_DOCKER --tag v6.0.2 --output-directory ../../../elf
 cd ../../..
 echo "Done!"
 echo ""
@@ -44,7 +44,7 @@ echo ""
 # Build the fibonacci example program.
 echo "Building fibonacci program..."
 cd programs/examples/fibonacci
-cargo prove build --elf-name spn-fibonacci-program $USE_DOCKER --tag v5.1.0 --output-directory ../../../elf
+cargo prove build --elf-name spn-fibonacci-program $USE_DOCKER --tag v6.0.2 --output-directory ../../../elf
 cd ../../..
 echo "Done!"
 echo ""


### PR DESCRIPTION
## Summary

Upgrades the VApp and prover node from SP1 V5 to SP1 V6. As the majority of proof requests on the network are now SP1 V6, switching V6 to the primary version means a greater percentage of proofs can have the stronger cryptographic security guarantees of native SP1 proof verification, rather than falling back to signature-based verification.

### Dependency & Toolchain Changes
- All `sp1-*` workspace deps: `5.2.3` → `6.1.0`
- zkVM program `sp1-zkvm` deps consolidated to `{ workspace = true }` (were hardcoded at `5.1.0`)
- Rust toolchain: `1.88` → `1.91` (SP1 V6 minimum)
- Updated `[patch.crates-io]` entries (`sha2`, `sha3`, `tiny-keccak`, `k256`, `p256`) to `sp1-6.0.0` tags; removed `crypto-bigint` (no longer patched in V6)
- CI: updated `action.yml` and `pr.yml` to install Rust 1.91 and SP1 V6

### `is_primary` Version Change
- **V6 is now the primary version**: `is_primary_version` check changed from `starts_with("sp1-v5")` to `starts_with("sp1-v6")`
- V6 Compressed proofs now use native SP1 recursive verification (strongest guarantee)
- V5 Compressed proofs fall back to signature-based verification (still supported, just not primary)

### SP1 V6 API Migration
- `EnvProver::new()`, `setup()`, `execute()`, `prove()` are now async
- `spawn_blocking` + `catch_unwind` → `tokio::spawn` (panics caught via `JoinError`)
- `include_elf!` now returns `Elf` enum instead of `&[u8]`
- `report.gas` field → `report.gas()` accessor
- `Calibrator::calibrate()` trait made async
- Aggregation `build.rs` wrapped in `tokio::runtime` for async `setup()`
- `verify_sp1_proof` unchanged — V6 preserves the same public API internally

### ELF Rebuilds
- `x.sh` build tags updated to `v6.1.0`
- Target architecture changed from `riscv32im` to `riscv64im-succinct-zkvm-elf`

## Test Plan
- [ ] `cargo check --workspace` passes (excluding zkVM programs which need SP1 toolchain)
- [ ] `cargo test --release` passes (vapp state tests, including V5 backward-compat tests)
- [ ] `cargo fmt --check` passes
- [ ] ELFs rebuild successfully via `./x.sh`
- [ ] Verify V6 proofs clear with native verification on testnet
- [ ] Verify V5 proofs clear with signature verification (backward compat)