### PR TITLE
feat(proto): expose GetProvePrice RPC for external clients

### DIFF
--- a/crates/types/network/src/network.rs
+++ b/crates/types/network/src/network.rs
@@ -1048,6 +1048,31 @@ pub mod prover_network_client {
                 .insert(GrpcMethod::new("network.ProverNetwork", "Settle"));
             self.inner.unary(req, path, codec).await
         }
+        /// Get the current PROVE token price in USD.
+        pub async fn get_prove_price(
+            &mut self,
+            request: impl tonic::IntoRequest<super::super::types::GetProvePriceRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::super::types::GetProvePriceResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/network.ProverNetwork/GetProvePrice",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("network.ProverNetwork", "GetProvePrice"));
+            self.inner.unary(req, path, codec).await
+        }
         /// Get the provers that have historically had reliable uptime.
         pub async fn get_provers_by_uptime(
             &mut self,
@@ -1991,6 +2016,14 @@ pub mod prover_network_server {
             request: tonic::Request<super::super::types::SettleRequest>,
         ) -> std::result::Result<
             tonic::Response<super::super::types::SettleResponse>,
+            tonic::Status,
+        >;
+        /// Get the current PROVE token price in USD.
+        async fn get_prove_price(
+            &self,
+            request: tonic::Request<super::super::types::GetProvePriceRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::super::types::GetProvePriceResponse>,
             tonic::Status,
         >;
         /// Get the provers that have historically had reliable uptime.
@@ -4010,6 +4043,54 @@ pub mod prover_network_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = SettleSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/network.ProverNetwork/GetProvePrice" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetProvePriceSvc<T: ProverNetwork>(pub Arc<T>);
+                    impl<
+                        T: ProverNetwork,
+                    > tonic::server::UnaryService<
+                        super::super::types::GetProvePriceRequest,
+                    > for GetProvePriceSvc<T> {
+                        type Response = super::super::types::GetProvePriceResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<
+                                super::super::types::GetProvePriceRequest,
+                            >,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as ProverNetwork>::get_prove_price(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetProvePriceSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/crates/types/network/src/types.rs
+++ b/crates/types/network/src/types.rs
@@ -1411,6 +1411,22 @@ pub struct SettleResponse {
 pub struct SettleResponseBody {}
 #[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct GetProvePriceRequest {}
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetProvePriceResponse {
+    /// The current price of PROVE token in USD as a decimal string.
+    #[prost(string, tag = "1")]
+    pub price: ::prost::alloc::string::String,
+    /// The unix timestamp when the price was last updated.
+    #[prost(int64, tag = "2")]
+    pub last_updated: i64,
+    /// The 24-hour price change percentage as a decimal string. Empty if unknown.
+    #[prost(string, tag = "3")]
+    pub percent_change_24h: ::prost::alloc::string::String,
+}
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct GetProversByUptimeRequest {
     /// Whether to only return high availability provers.
     #[prost(bool, tag = "1")]

--- a/proto/network.proto
+++ b/proto/network.proto
@@ -130,6 +130,8 @@ service ProverNetwork {
   // Settle the bids on a proof request to choose the assigned prover. Only callable by
   // the approved auctioneer.
   rpc Settle(types.SettleRequest) returns (types.SettleResponse) {}
+  // Get the current PROVE token price in USD.
+  rpc GetProvePrice(types.GetProvePriceRequest) returns (types.GetProvePriceResponse) {}
   // Get the provers that have historically had reliable uptime.
   rpc GetProversByUptime(types.GetProversByUptimeRequest) returns (types.GetProversByUptimeResponse) {}
   // Get settleable proof requests that have passed auction period and have bids.

--- a/proto/types.proto
+++ b/proto/types.proto
@@ -1076,6 +1076,18 @@ message SettleResponse {
 
 message SettleResponseBody {}
 
+message GetProvePriceRequest {
+}
+
+message GetProvePriceResponse {
+  // The current price of PROVE token in USD as a decimal string.
+  string price = 1;
+  // The unix timestamp when the price was last updated.
+  int64 last_updated = 2;
+  // The 24-hour price change percentage as a decimal string. Empty if unknown.
+  string percent_change_24h = 3;
+}
+
 message GetProversByUptimeRequest {
   // Whether to only return high availability provers.
   bool high_availability_only = 1;


### PR DESCRIPTION
The RPC already exists internally and serves PROVE/USD to our explorer. Exposing it in the public SDK lets external clients (e.g. provers running the sp1-cluster bidder) consume the same source for USD-aware bidding logic — no separate vendor API or scraping needed.