### PR TITLE
feat: add spn-pricing crate with parser and conversion math

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7598,6 +7598,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "spn-pricing"
+version = "0.1.0"
+dependencies = [
+ "alloy",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "spn-rpc"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7601,7 +7601,7 @@ dependencies = [
 name = "spn-pricing"
 version = "0.1.0"
 dependencies = [
- "alloy",
+ "alloy-primitives",
  "async-trait",
  "thiserror 1.0.69",
  "time",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7602,7 +7602,9 @@ name = "spn-pricing"
 version = "0.1.0"
 dependencies = [
  "alloy",
+ "async-trait",
  "thiserror 1.0.69",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,6 +128,7 @@ sqlx = { version = "0.8", features = [
     "time",
 ] }
 thiserror = "1.0.63"
+time = "0.3"
 tokio = { version = "1.0", features = ["full"] }
 url = "2.5.0"
 reqwest = "0.12.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["cryptography"]
 members = [
     "bin/node",
     "crates/network/artifacts",
+    "crates/network/pricing",
     "crates/network/rpc",
     "crates/network/utils",
     "crates/node/calibrator",
@@ -29,6 +30,7 @@ resolver = "2"
 [workspace.dependencies]
 # spn
 spn-artifacts = { path = "crates/network/artifacts" }
+spn-pricing = { path = "crates/network/pricing" }
 spn-rpc = { path = "crates/network/rpc" }
 spn-utils = { path = "crates/network/utils" }
 spn-calibrator = { path = "crates/node/calibrator" }

--- a/crates/network/pricing/Cargo.toml
+++ b/crates/network/pricing/Cargo.toml
@@ -10,4 +10,6 @@ categories = { workspace = true }
 
 [dependencies]
 alloy = { workspace = true }
+async-trait = { workspace = true }
 thiserror = { workspace = true }
+time = { workspace = true }

--- a/crates/network/pricing/Cargo.toml
+++ b/crates/network/pricing/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "spn-pricing"
+description = "PROVE/USD price parsing and USD→PROVE conversion shared across SPN consumers."
+version = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+keywords = { workspace = true }
+categories = { workspace = true }
+
+[dependencies]
+alloy = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/network/pricing/Cargo.toml
+++ b/crates/network/pricing/Cargo.toml
@@ -9,7 +9,7 @@ keywords = { workspace = true }
 categories = { workspace = true }
 
 [dependencies]
-alloy = { workspace = true }
+alloy-primitives = { workspace = true }
 async-trait = { workspace = true }
 thiserror = { workspace = true }
 time = { workspace = true }

--- a/crates/network/pricing/src/error.rs
+++ b/crates/network/pricing/src/error.rs
@@ -2,10 +2,15 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum PriceError {
+    #[error("no PROVE/USD price available (no live read, no last-known cache)")]
+    NoPriceAvailable,
     #[error("PROVE/USD reported as zero, refusing to divide")]
     ZeroProvePrice,
     #[error("integer overflow in price conversion")]
     Overflow,
     #[error("could not parse PROVE/USD value: {0}")]
     PriceConversion(String),
+    /// Catch-all for implementation-specific failures (DB drivers, RPC clients, etc.).
+    #[error("price provider failed: {0}")]
+    Provider(String),
 }

--- a/crates/network/pricing/src/error.rs
+++ b/crates/network/pricing/src/error.rs
@@ -1,0 +1,11 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum PriceError {
+    #[error("PROVE/USD reported as zero, refusing to divide")]
+    ZeroProvePrice,
+    #[error("integer overflow in price conversion")]
+    Overflow,
+    #[error("could not parse PROVE/USD value: {0}")]
+    PriceConversion(String),
+}

--- a/crates/network/pricing/src/lib.rs
+++ b/crates/network/pricing/src/lib.rs
@@ -1,0 +1,10 @@
+//! PROVE/USD wire-format parsing and USD→PROVE conversion shared across SPN consumers
+//! (proxy, bidders, indexers, third-party clients). These are protocol-adjacent helpers:
+//! every consumer of `GetProvePrice` and every implementer of dynamic `max_price_per_pgu`
+//! must agree on the parsing and unit math, so they live here as a single source of truth.
+
+mod error;
+mod math;
+
+pub use error::PriceError;
+pub use math::{compute_max_price_per_pgu_wei, parse_usd_micros};

--- a/crates/network/pricing/src/lib.rs
+++ b/crates/network/pricing/src/lib.rs
@@ -5,6 +5,8 @@
 
 mod error;
 mod math;
+mod provider;
 
 pub use error::PriceError;
 pub use math::{compute_max_price_per_pgu_wei, parse_usd_micros};
+pub use provider::{PriceProvider, ProvePrice};

--- a/crates/network/pricing/src/math.rs
+++ b/crates/network/pricing/src/math.rs
@@ -1,0 +1,136 @@
+use alloy::primitives::U256;
+
+use crate::error::PriceError;
+
+/// Compute a `max_price_per_pgu` ceiling in PROVE wei from a USD target.
+///
+/// ```text
+/// ceiling_wei_per_pgu = (target_usd_micros_per_bpgu * 10^9) / prove_usd_micros
+/// ```
+///
+/// Inputs are both integers in µUSD-denominated units:
+/// - `target_usd_micros_per_bpgu`: µUSD per BPGU (1 BPGU = 10^9 PGU). 200_000 = $0.20/BPGU.
+/// - `prove_usd_micros`: µUSD per 1 PROVE. 400_000 = $0.40/PROVE.
+///
+/// Result rounds **down**, which is conservative for the consumer: the realized $-value
+/// can never inadvertently exceed `target` due to rounding.
+pub fn compute_max_price_per_pgu_wei(
+    target_usd_micros_per_bpgu: u64,
+    prove_usd_micros: u64,
+) -> Result<U256, PriceError> {
+    if prove_usd_micros == 0 {
+        return Err(PriceError::ZeroProvePrice);
+    }
+    let scale = U256::from(10u64).pow(U256::from(9u64));
+    let numerator =
+        U256::from(target_usd_micros_per_bpgu).checked_mul(scale).ok_or(PriceError::Overflow)?;
+    Ok(numerator / U256::from(prove_usd_micros))
+}
+
+/// Parse a PROVE/USD decimal string (e.g. `"0.40"`) into µUSD (`400_000`).
+///
+/// The price must be finite and strictly positive. A zero or negative PROVE price is
+/// meaningless and would later force a divide-by-zero in [`compute_max_price_per_pgu_wei`].
+/// The result is rounded to nearest µUSD and is always `>= 1`: a price so small it rounds
+/// below 1 µUSD is rejected, so the returned value is strictly positive.
+pub fn parse_usd_micros(s: &str) -> Result<u64, PriceError> {
+    let price: f64 = s.trim().parse().map_err(|_| {
+        PriceError::PriceConversion(format!("could not parse PROVE/USD {s:?} as f64"))
+    })?;
+    if !price.is_finite() || price <= 0.0 {
+        return Err(PriceError::PriceConversion(format!(
+            "PROVE/USD must be finite and positive, got {price}"
+        )));
+    }
+    let micros = (price * 1_000_000.0).round();
+    if micros < 1.0 {
+        return Err(PriceError::PriceConversion(format!(
+            "PROVE/USD {price} rounds below 1 µUSD; too small to represent"
+        )));
+    }
+    if micros >= u64::MAX as f64 {
+        return Err(PriceError::PriceConversion(format!(
+            "PROVE/USD {price} is out of representable µUSD range"
+        )));
+    }
+    Ok(micros as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Reference anchor: $0.20/BPGU at PROVE=$0.40 → 500_000_000 wei/PGU = 0.5 PROVE/BPGU.
+    #[test]
+    fn reference_anchor_matches_legacy_500m() {
+        let wei = compute_max_price_per_pgu_wei(200_000, 400_000).unwrap();
+        assert_eq!(wei, U256::from(500_000_000u64));
+    }
+
+    /// Lower PROVE price → higher PROVE ceiling (more wei needed per BPGU).
+    #[test]
+    fn lower_prove_price_raises_prove_ceiling() {
+        let wei = compute_max_price_per_pgu_wei(200_000, 200_000).unwrap();
+        assert_eq!(wei, U256::from(1_000_000_000u64));
+    }
+
+    /// Higher PROVE price → lower PROVE ceiling.
+    #[test]
+    fn higher_prove_price_lowers_prove_ceiling() {
+        let wei = compute_max_price_per_pgu_wei(200_000, 1_000_000).unwrap();
+        assert_eq!(wei, U256::from(200_000_000u64));
+    }
+
+    #[test]
+    fn zero_prove_price_errors() {
+        assert!(matches!(
+            compute_max_price_per_pgu_wei(200_000, 0),
+            Err(PriceError::ZeroProvePrice)
+        ));
+    }
+
+    /// Division rounds down.
+    #[test]
+    fn rounds_down() {
+        // target=1, prove=3 → 1 * 10^9 / 3 = 333_333_333 (truncated).
+        let wei = compute_max_price_per_pgu_wei(1, 3).unwrap();
+        assert_eq!(wei, U256::from(333_333_333u64));
+    }
+
+    /// `u64::MAX * 10^9` fits in U256 (U256 maxes at ~1.16e77; this is ~1.8e28).
+    #[test]
+    fn very_large_target_does_not_overflow_u256() {
+        let wei = compute_max_price_per_pgu_wei(u64::MAX, 1_000_000).unwrap();
+        assert!(wei > U256::ZERO);
+    }
+
+    #[test]
+    fn parse_usd_micros_typical() {
+        assert_eq!(parse_usd_micros("0.40").unwrap(), 400_000);
+        assert_eq!(parse_usd_micros("0.2337").unwrap(), 233_700);
+        assert_eq!(parse_usd_micros(" 1 ").unwrap(), 1_000_000);
+    }
+
+    #[test]
+    fn parse_usd_micros_rounds_to_nearest() {
+        // 0.2337005 → 233_700.5 → rounds to 233_701.
+        assert_eq!(parse_usd_micros("0.2337005").unwrap(), 233_701);
+    }
+
+    #[test]
+    fn parse_usd_micros_rejects_non_positive_and_garbage() {
+        assert!(parse_usd_micros("0").is_err());
+        assert!(parse_usd_micros("-0.5").is_err());
+        assert!(parse_usd_micros("inf").is_err());
+        assert!(parse_usd_micros("NaN").is_err());
+        assert!(parse_usd_micros("abc").is_err());
+    }
+
+    #[test]
+    fn parse_usd_micros_subunit_boundary() {
+        // 0.0000004 USD = 0.4 µUSD → rounds to 0, must be rejected (not Ok(0)).
+        assert!(parse_usd_micros("0.0000004").is_err());
+        // 0.0000005 USD = 0.5 µUSD → rounds to 1, the smallest accepted value.
+        assert_eq!(parse_usd_micros("0.0000005").unwrap(), 1);
+    }
+}

--- a/crates/network/pricing/src/math.rs
+++ b/crates/network/pricing/src/math.rs
@@ -1,4 +1,4 @@
-use alloy::primitives::U256;
+use alloy_primitives::U256;
 
 use crate::error::PriceError;
 

--- a/crates/network/pricing/src/provider.rs
+++ b/crates/network/pricing/src/provider.rs
@@ -1,0 +1,30 @@
+use async_trait::async_trait;
+use time::OffsetDateTime;
+
+use crate::error::PriceError;
+
+/// A PROVE/USD reading and the time it applies to.
+#[derive(Clone, Debug)]
+pub struct ProvePrice {
+    /// µUSD per 1 PROVE.
+    pub usd_micros: u64,
+    /// When this price reading applies. Callers compute staleness themselves as
+    /// `OffsetDateTime::now_utc() - as_of` so cached values reflect *current* age,
+    /// not the age at fetch time.
+    pub as_of: OffsetDateTime,
+}
+
+/// Source of a PROVE/USD reading.
+///
+/// Implementations may back this with any source (DB row, RPC call, in-memory cache, mock).
+/// Implementation-specific failures (DB driver errors, RPC errors, etc.) flow through
+/// [`PriceError::Provider`] via `.to_string()`.
+///
+/// Implementations should attempt a live read first and fall back to the last-known value
+/// on transient failure. Only return `Err` when *no* value is available — not even a cached
+/// one. Callers may inspect [`ProvePrice::as_of`] to apply their own staleness threshold.
+#[async_trait]
+pub trait PriceProvider: Send + Sync {
+    /// Return the freshest available PROVE/USD reading.
+    async fn current_prove_usd_micros(&self) -> Result<ProvePrice, PriceError>;
+}


### PR DESCRIPTION
Adds `spn-pricing` crate to the workspace at `crates/network/pricing/`, containing the public-facing protocol math: `parse_usd_micros` (interprets `GetProvePrice` wire response) and `compute_max_price_per_pgu_wei` (USD target → PROVE wei).