### PR TITLE
feat(pricing): add round_down_to_tick helper

### DIFF
--- a/crates/network/pricing/src/lib.rs
+++ b/crates/network/pricing/src/lib.rs
@@ -8,5 +8,7 @@ mod math;
 mod provider;
 
 pub use error::PriceError;
-pub use math::{compute_max_price_per_pgu_wei, parse_usd_micros, usd_micros_to_prove_wei};
+pub use math::{
+    compute_max_price_per_pgu_wei, parse_usd_micros, round_down_to_tick, usd_micros_to_prove_wei,
+};
 pub use provider::{PriceProvider, ProvePrice};

--- a/crates/network/pricing/src/math.rs
+++ b/crates/network/pricing/src/math.rs
@@ -41,7 +41,8 @@ pub fn compute_max_price_per_pgu_wei(
 /// Rounding down stays at or below the input — never above — so publish-side and bid-side
 /// callers both stay within their original bound after alignment.
 pub fn round_down_to_tick(wei: U256, required_bid_multiple: U256) -> U256 {
-    if required_bid_multiple <= U256::from(1u64) {
+    const ONE: U256 = U256::from_limbs([1, 0, 0, 0]);
+    if required_bid_multiple <= ONE {
         return wei;
     }
     wei - (wei % required_bid_multiple)

--- a/crates/network/pricing/src/math.rs
+++ b/crates/network/pricing/src/math.rs
@@ -35,6 +35,18 @@ pub fn compute_max_price_per_pgu_wei(
     Ok(wei_per_bpgu / pgu_per_bpgu)
 }
 
+/// Floor `wei` to a multiple of `required_bid_multiple`. `0` and `1` are sentinels for
+/// "no tick" and return `wei` unchanged.
+///
+/// Rounding down stays at or below the input — never above — so publish-side and bid-side
+/// callers both stay within their original bound after alignment.
+pub fn round_down_to_tick(wei: U256, required_bid_multiple: U256) -> U256 {
+    if required_bid_multiple <= U256::from(1u64) {
+        return wei;
+    }
+    wei - (wei % required_bid_multiple)
+}
+
 /// Parse a PROVE/USD decimal string (e.g. `"0.40"`) into µUSD (`400_000`).
 ///
 /// The price must be finite and strictly positive. A zero or negative PROVE price is
@@ -168,5 +180,32 @@ mod tests {
         assert!(parse_usd_micros("0.0000004").is_err());
         // 0.0000005 USD = 0.5 µUSD → rounds to 1, the smallest accepted value.
         assert_eq!(parse_usd_micros("0.0000005").unwrap(), 1);
+    }
+
+    #[test]
+    fn round_down_to_tick_floors_to_multiple() {
+        assert_eq!(
+            round_down_to_tick(U256::from(642_742_367u64), U256::from(10_000_000u64)),
+            U256::from(640_000_000u64),
+        );
+    }
+
+    #[test]
+    fn round_down_to_tick_aligned_input_unchanged() {
+        assert_eq!(
+            round_down_to_tick(U256::from(500_000_000u64), U256::from(10_000_000u64)),
+            U256::from(500_000_000u64),
+        );
+    }
+
+    #[test]
+    fn round_down_to_tick_zero_and_one_are_no_ops() {
+        assert_eq!(round_down_to_tick(U256::from(123u64), U256::ZERO), U256::from(123u64));
+        assert_eq!(round_down_to_tick(U256::from(123u64), U256::from(1u64)), U256::from(123u64));
+    }
+
+    #[test]
+    fn round_down_to_tick_sub_tick_rounds_to_zero() {
+        assert_eq!(round_down_to_tick(U256::from(5u64), U256::from(10u64)), U256::ZERO);
     }
 }


### PR DESCRIPTION
## Description
Adds `spn_pricing::round_down_to_tick(wei, required_bid_multiple)` — a shared helper that floors a wei value to the on-chain bid tick.

## Why
the auction rejects bids that aren't multiples of `required_bid_multiple`, but USD-anchored values (RPC's published `max_price_per_pgu`, both bidders' USD-anchored bids) almost never land on a multiple. Today each consumer would need its own copy of the same 4-line floor; centralizing it here keeps the alignment rule next to `compute_max_price_per_pgu_wei` and prevents drift.

## Remark
Sentinels `0` and `1` pass `wei` through unchanged so callers can disable alignment without an `Option` wrapper. Rounding is always *down* — conservative for both publish-side (never above target) and bid-side (never above requester cap).