### PR TITLE
feat(proto): add prover info report wire contract

### DIFF
--- a/crates/types/network/src/network.rs
+++ b/crates/types/network/src/network.rs
@@ -1219,6 +1219,34 @@ pub mod prover_network_client {
                 .insert(GrpcMethod::new("network.ProverNetwork", "SuspendProver"));
             self.inner.unary(req, path, codec).await
         }
+        /// Report the self-reported build identity of a prover's cluster components (fulfiller,
+        /// coordinator, workers). Debugging telemetry signed by the prover key; not attestation.
+        pub async fn report_prover_info(
+            &mut self,
+            request: impl tonic::IntoRequest<
+                super::super::types::ReportProverInfoRequest,
+            >,
+        ) -> std::result::Result<
+            tonic::Response<super::super::types::ReportProverInfoResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/network.ProverNetwork/ReportProverInfo",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("network.ProverNetwork", "ReportProverInfo"));
+            self.inner.unary(req, path, codec).await
+        }
         /// Sign in with Ethereum
         pub async fn sign_in(
             &mut self,
@@ -2099,6 +2127,15 @@ pub mod prover_network_server {
             request: tonic::Request<super::super::types::SuspendProverRequest>,
         ) -> std::result::Result<
             tonic::Response<super::super::types::SuspendProverResponse>,
+            tonic::Status,
+        >;
+        /// Report the self-reported build identity of a prover's cluster components (fulfiller,
+        /// coordinator, workers). Debugging telemetry signed by the prover key; not attestation.
+        async fn report_prover_info(
+            &self,
+            request: tonic::Request<super::super::types::ReportProverInfoRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::super::types::ReportProverInfoResponse>,
             tonic::Status,
         >;
         /// Sign in with Ethereum
@@ -4387,6 +4424,55 @@ pub mod prover_network_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = SuspendProverSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/network.ProverNetwork/ReportProverInfo" => {
+                    #[allow(non_camel_case_types)]
+                    struct ReportProverInfoSvc<T: ProverNetwork>(pub Arc<T>);
+                    impl<
+                        T: ProverNetwork,
+                    > tonic::server::UnaryService<
+                        super::super::types::ReportProverInfoRequest,
+                    > for ReportProverInfoSvc<T> {
+                        type Response = super::super::types::ReportProverInfoResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<
+                                super::super::types::ReportProverInfoRequest,
+                            >,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as ProverNetwork>::report_prover_info(&inner, request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = ReportProverInfoSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/crates/types/network/src/types.rs
+++ b/crates/types/network/src/types.rs
@@ -1415,9 +1415,6 @@ pub struct ComponentInfo {
     /// The container image tag the component is running.
     #[prost(string, tag = "5")]
     pub image_tag: ::prost::alloc::string::String,
-    /// The build timestamp.
-    #[prost(string, tag = "6")]
-    pub build_timestamp: ::prost::alloc::string::String,
 }
 #[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]

--- a/crates/types/network/src/types.rs
+++ b/crates/types/network/src/types.rs
@@ -1370,6 +1370,67 @@ pub struct BidResponse {
 pub struct BidResponseBody {}
 #[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ReportProverInfoRequest {
+    /// The message format of the body.
+    #[prost(enumeration = "MessageFormat", tag = "1")]
+    pub format: i32,
+    /// The signature of the sender.
+    #[prost(bytes = "vec", tag = "2")]
+    pub signature: ::prost::alloc::vec::Vec<u8>,
+    /// The body of the request.
+    #[prost(message, optional, tag = "3")]
+    pub body: ::core::option::Option<ReportProverInfoRequestBody>,
+}
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ReportProverInfoRequestBody {
+    /// The domain separator for the request.
+    #[prost(bytes = "vec", tag = "1")]
+    pub domain: ::prost::alloc::vec::Vec<u8>,
+    /// The address of the prover the report is for. Must match the signer-resolved prover.
+    #[prost(bytes = "vec", tag = "2")]
+    pub prover: ::prost::alloc::vec::Vec<u8>,
+    /// The build identity of one or more cluster components.
+    #[prost(message, repeated, tag = "3")]
+    pub components: ::prost::alloc::vec::Vec<ComponentInfo>,
+}
+/// Self-reported build identity of a single cluster component. This is debugging
+/// telemetry, not verified attestation. `component` is a free-form string validated
+/// against a server-side allowlist (fulfiller, coordinator, gpu-node, cpu-node).
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ComponentInfo {
+    /// The component kind, e.g. "fulfiller", "coordinator", "gpu-node", "cpu-node".
+    #[prost(string, tag = "1")]
+    pub component: ::prost::alloc::string::String,
+    /// The component instance identifier ("" for singletons, worker id for nodes).
+    #[prost(string, tag = "2")]
+    pub instance_id: ::prost::alloc::string::String,
+    /// The crate version (CARGO_PKG_VERSION).
+    #[prost(string, tag = "3")]
+    pub version: ::prost::alloc::string::String,
+    /// The git commit the binary was built from.
+    #[prost(string, tag = "4")]
+    pub git_sha: ::prost::alloc::string::String,
+    /// The container image tag the component is running.
+    #[prost(string, tag = "5")]
+    pub image_tag: ::prost::alloc::string::String,
+    /// The build timestamp.
+    #[prost(string, tag = "6")]
+    pub build_timestamp: ::prost::alloc::string::String,
+}
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct ReportProverInfoResponse {
+    /// The body of the response.
+    #[prost(message, optional, tag = "1")]
+    pub body: ::core::option::Option<ReportProverInfoResponseBody>,
+}
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct ReportProverInfoResponseBody {}
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SettleRequest {
     /// The message format of the body.
     #[prost(enumeration = "MessageFormat", tag = "1")]

--- a/proto/network.proto
+++ b/proto/network.proto
@@ -147,6 +147,9 @@ service ProverNetwork {
   // Suspend a prover.
   rpc SuspendProver(types.SuspendProverRequest)
       returns (types.SuspendProverResponse) {}
+  // Report the self-reported build identity of a prover's cluster components (fulfiller,
+  // coordinator, workers). Debugging telemetry signed by the prover key; not attestation.
+  rpc ReportProverInfo(types.ReportProverInfoRequest) returns (types.ReportProverInfoResponse) {}
 
   /*
    * Frontend

--- a/proto/types.proto
+++ b/proto/types.proto
@@ -1080,8 +1080,6 @@ message ComponentInfo {
   string git_sha = 4;
   // The container image tag the component is running.
   string image_tag = 5;
-  // The build timestamp.
-  string build_timestamp = 6;
 }
 
 message ReportProverInfoResponse {

--- a/proto/types.proto
+++ b/proto/types.proto
@@ -1048,6 +1048,49 @@ message BidResponse {
 
 message BidResponseBody {}
 
+message ReportProverInfoRequest {
+  // The message format of the body.
+  MessageFormat format = 1;
+  // The signature of the sender.
+  bytes signature = 2;
+  // The body of the request.
+  ReportProverInfoRequestBody body = 3;
+}
+
+message ReportProverInfoRequestBody {
+  // The domain separator for the request.
+  bytes domain = 1;
+  // The address of the prover the report is for. Must match the signer-resolved prover.
+  bytes prover = 2;
+  // The build identity of one or more cluster components.
+  repeated ComponentInfo components = 3;
+}
+
+// Self-reported build identity of a single cluster component. This is debugging
+// telemetry, not verified attestation. `component` is a free-form string validated
+// against a server-side allowlist (fulfiller, coordinator, gpu-node, cpu-node).
+message ComponentInfo {
+  // The component kind, e.g. "fulfiller", "coordinator", "gpu-node", "cpu-node".
+  string component = 1;
+  // The component instance identifier ("" for singletons, worker id for nodes).
+  string instance_id = 2;
+  // The crate version (CARGO_PKG_VERSION).
+  string version = 3;
+  // The git commit the binary was built from.
+  string git_sha = 4;
+  // The container image tag the component is running.
+  string image_tag = 5;
+  // The build timestamp.
+  string build_timestamp = 6;
+}
+
+message ReportProverInfoResponse {
+  // The body of the response.
+  ReportProverInfoResponseBody body = 1;
+}
+
+message ReportProverInfoResponseBody {}
+
 message SettleRequest {
   // The message format of the body.
   MessageFormat format = 1;


### PR DESCRIPTION
## Summary

Adds the public SPN wire contract for prover build reporting.

`ReportProverInfo` lets a prover-signed process report self-reported build metadata for cluster components (fulfiller, coordinator, workers). This PR is the proto contract + regenerated Rust types only — no server storage or producer wiring.

## What Changed

- Adds `ReportProverInfo` to `ProverNetwork`.
- Adds `ReportProverInfoRequest`, `ReportProverInfoRequestBody`, `ComponentInfo`, `ReportProverInfoResponse`, `ReportProverInfoResponseBody`.
- `ComponentInfo.component` is an intentional `string` (the network-services server enforces a strict allowlist).
- Signing uses the existing blanket `Signable` trait; no per-request macro.

## Field Numbers

`ReportProverInfoRequest`: `format=1`, `signature=2`, `body=3`
`ReportProverInfoRequestBody`: `domain=1`, `prover=2`, `components=3`
`ComponentInfo`: `component=1`, `instance_id=2`, `version=3`, `git_sha=4`, `image_tag=5`

## Scope

Phase 1 only — no handler, no DB, no sp1/sp1-cluster wiring, no SDK exposure, no attestation semantics. Values are self-reported debugging telemetry, not verified deployment truth.

## Review updates

- Dropped `build_timestamp` (per review feedback): it is not a stable identity signal — the same `git_sha` can be rebuilt — so it adds no reliable discriminator. The meaningful time for this feature is server-owned observation time (`first_reported_at`, `last_reported_at`, `first_seen_at`).
