### PR TITLE
feat(proto): remove ComponentInfo.instance_id from ReportProverInfo contract

### DIFF
--- a/crates/types/network/src/types.rs
+++ b/crates/types/network/src/types.rs
@@ -1405,23 +1405,21 @@ pub struct ReportProverInfoRequestBody {
 /// Self-reported build identity of a single cluster component. This is debugging
 /// telemetry, not verified attestation. `component` is a free-form string validated
 /// against a server-side allowlist (fulfiller, coordinator, gpu-node, cpu-node).
+/// Keyed by build identity (component, version, git_sha, image_tag).
 #[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ComponentInfo {
     /// The component kind, e.g. "fulfiller", "coordinator", "gpu-node", "cpu-node".
     #[prost(string, tag = "1")]
     pub component: ::prost::alloc::string::String,
-    /// The component instance identifier ("" for singletons, worker id for nodes).
-    #[prost(string, tag = "2")]
-    pub instance_id: ::prost::alloc::string::String,
     /// The crate version (CARGO_PKG_VERSION).
-    #[prost(string, tag = "3")]
+    #[prost(string, tag = "2")]
     pub version: ::prost::alloc::string::String,
     /// The git commit the binary was built from.
-    #[prost(string, tag = "4")]
+    #[prost(string, tag = "3")]
     pub git_sha: ::prost::alloc::string::String,
     /// The container image tag the component is running.
-    #[prost(string, tag = "5")]
+    #[prost(string, tag = "4")]
     pub image_tag: ::prost::alloc::string::String,
 }
 #[derive(serde::Serialize, serde::Deserialize)]

--- a/proto/types.proto
+++ b/proto/types.proto
@@ -1076,17 +1076,16 @@ message ReportProverInfoRequestBody {
 // Self-reported build identity of a single cluster component. This is debugging
 // telemetry, not verified attestation. `component` is a free-form string validated
 // against a server-side allowlist (fulfiller, coordinator, gpu-node, cpu-node).
+// Keyed by build identity (component, version, git_sha, image_tag).
 message ComponentInfo {
   // The component kind, e.g. "fulfiller", "coordinator", "gpu-node", "cpu-node".
   string component = 1;
-  // The component instance identifier ("" for singletons, worker id for nodes).
-  string instance_id = 2;
   // The crate version (CARGO_PKG_VERSION).
-  string version = 3;
+  string version = 2;
   // The git commit the binary was built from.
-  string git_sha = 4;
+  string git_sha = 3;
   // The container image tag the component is running.
-  string image_tag = 5;
+  string image_tag = 4;
 }
 
 message ReportProverInfoResponse {


### PR DESCRIPTION
## Summary

Removes `ComponentInfo.instance_id` from the `ReportProverInfo` public wire contract. The field is removed outright (no `reserved` marker) since no producer traffic has shipped.

Worker IDs are ECS task IDs in the producer path, so they are launch identities rather than stable build identities. The build-reporting contract should describe active component builds, keyed by `(component, version, git_sha, image_tag)`, not per-worker instances.

## Notes

- `instance_id` was removed outright (no `reserved` marker) and the remaining build fields were renumbered contiguously (`version=2`, `git_sha=3`, `image_tag=4`), since no producer traffic has shipped.
- No producer traffic has been shipped yet; mainnet prover component runtime tables are still empty.
- No RPC/signing/domain semantics changed.


