### PR TITLE
feat(error-trace): add execute proof trace field

### DIFF
--- a/crates/types/network/src/error_trace.rs
+++ b/crates/types/network/src/error_trace.rs
@@ -20,9 +20,10 @@
 //!
 //! SYNC: this is a manually-kept duplicate of the canonical module in
 //! `succinctlabs/network-services` (PR #1191). The two proto repos are not
-//! auto-synced; `FailFulfillmentRequestBody.error_trace` is wire field 4 in
-//! both. Keep this file and its network-services twin logically identical —
-//! change them together.
+//! auto-synced; `FailFulfillmentRequestBody.error_trace` is wire field 4 and
+//! `ExecuteProofRequestBody.error_trace` is wire field 11 in both repos. Keep
+//! this file and its network-services twin logically identical — change them
+//! together.
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/types/network/src/types.rs
+++ b/crates/types/network/src/types.rs
@@ -290,6 +290,12 @@ pub struct ExecuteProofRequestBody {
     /// The variant of the transaction.
     #[prost(enumeration = "TransactionVariant", tag = "10")]
     pub variant: i32,
+    /// Optional bounded, sanitized structured failure trace, set when execution
+    /// failed. Same contract as FailFulfillmentRequestBody.error_trace: the network
+    /// re-validates and stores it in `requests.error_trace`. See
+    /// `spn_network_types::error_trace`.
+    #[prost(bytes = "vec", optional, tag = "11")]
+    pub error_trace: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
 }
 #[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/crates/vapp/tests/common/mod.rs
+++ b/crates/vapp/tests/common/mod.rs
@@ -651,6 +651,7 @@ pub fn create_clear_tx_with_options(
         punishment: None,
         failure_cause: None,
         variant: TransactionVariant::ExecuteVariant as i32,
+        error_trace: None,
     };
 
     // Create and sign execute.
@@ -963,6 +964,7 @@ pub fn create_clear_tx_with_public_values_hash(
         punishment: None,
         failure_cause: None,
         variant: TransactionVariant::ExecuteVariant as i32,
+        error_trace: None,
     };
 
     // Create and sign execute.
@@ -1170,6 +1172,7 @@ pub fn create_clear_tx_with_version(
         punishment: None,
         failure_cause: None,
         variant: TransactionVariant::ExecuteVariant as i32,
+        error_trace: None,
     };
 
     // Create and sign execute.

--- a/proto/types.proto
+++ b/proto/types.proto
@@ -235,6 +235,11 @@ message ExecuteProofRequestBody {
   optional ExecuteFailureCause failure_cause = 9;
   // The variant of the transaction.
   TransactionVariant variant = 10;
+  // Optional bounded, sanitized structured failure trace, set when execution
+  // failed. Same contract as FailFulfillmentRequestBody.error_trace: the network
+  // re-validates and stores it in `requests.error_trace`. See
+  // `spn_network_types::error_trace`.
+  optional bytes error_trace = 11;
 }
 
 message ExecuteProofResponse {


### PR DESCRIPTION
## Summary

- Adds optional `ExecuteProofRequestBody.error_trace = 11` to the network wire type.
- Keeps it wire-aligned with network-services `j/vapp`, which already receives, sanitizes, and stores this field (`requests.error_trace`).
- Enables the follow-up sp1-cluster-private `MainnetExecutor` wiring to send structured traces on `execute_proof`.

## Scope

- Wire contract only: proto field + regenerated Rust types.
- No producer wiring in this PR (sp1-cluster-private unchanged).
- No network-services / infra / release changes.
- Additive and backward-compatible: `optional` field, next free tag (11); old producers omitting it decode as `None`, old consumers ignore it.
- Does not capture guest panic payload/location (separate SP1 stderr-capture work).

## Validation

- `cargo build -p spn-network-types --release` (regenerates `src/types.rs` via build.rs)
- `cargo test -p spn-network-types error_trace --lib` → 52 passed
- `cargo fmt -p spn-network-types -- --check` → clean
- `git diff --check` → clean
- Diff limited to `proto/types.proto` (+ field) and `crates/types/network/src/types.rs` (regenerated): `#[prost(bytes = "vec", optional, tag = "11")] error_trace`.
