### PR TITLE
feat(proto): add prover requirements and status wire contract

### DIFF
--- a/crates/types/network/src/network.rs
+++ b/crates/types/network/src/network.rs
@@ -1219,6 +1219,63 @@ pub mod prover_network_client {
                 .insert(GrpcMethod::new("network.ProverNetwork", "SuspendProver"));
             self.inner.unary(req, path, codec).await
         }
+        /// Get the network's prover performance requirements. A fulfilled request counts
+        /// toward a prover's success rate only if fulfilled within
+        /// `GREATEST(gas / min_mgas_per_second, floor_latency_seconds)` seconds of request
+        /// creation.
+        pub async fn get_prover_requirements(
+            &mut self,
+            request: impl tonic::IntoRequest<
+                super::super::types::GetProverRequirementsRequest,
+            >,
+        ) -> std::result::Result<
+            tonic::Response<super::super::types::GetProverRequirementsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/network.ProverNetwork/GetProverRequirements",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("network.ProverNetwork", "GetProverRequirements"),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        /// Get a prover's whitelist and suspension status.
+        pub async fn get_prover_status(
+            &mut self,
+            request: impl tonic::IntoRequest<super::super::types::GetProverStatusRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::super::types::GetProverStatusResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/network.ProverNetwork/GetProverStatus",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("network.ProverNetwork", "GetProverStatus"));
+            self.inner.unary(req, path, codec).await
+        }
         /// Report the self-reported build identity of a prover's cluster components (fulfiller,
         /// coordinator, workers). Debugging telemetry signed by the prover key; not attestation.
         pub async fn report_prover_info(
@@ -2127,6 +2184,25 @@ pub mod prover_network_server {
             request: tonic::Request<super::super::types::SuspendProverRequest>,
         ) -> std::result::Result<
             tonic::Response<super::super::types::SuspendProverResponse>,
+            tonic::Status,
+        >;
+        /// Get the network's prover performance requirements. A fulfilled request counts
+        /// toward a prover's success rate only if fulfilled within
+        /// `GREATEST(gas / min_mgas_per_second, floor_latency_seconds)` seconds of request
+        /// creation.
+        async fn get_prover_requirements(
+            &self,
+            request: tonic::Request<super::super::types::GetProverRequirementsRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::super::types::GetProverRequirementsResponse>,
+            tonic::Status,
+        >;
+        /// Get a prover's whitelist and suspension status.
+        async fn get_prover_status(
+            &self,
+            request: tonic::Request<super::super::types::GetProverStatusRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::super::types::GetProverStatusResponse>,
             tonic::Status,
         >;
         /// Report the self-reported build identity of a prover's cluster components (fulfiller,
@@ -4424,6 +4500,107 @@ pub mod prover_network_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = SuspendProverSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/network.ProverNetwork/GetProverRequirements" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetProverRequirementsSvc<T: ProverNetwork>(pub Arc<T>);
+                    impl<
+                        T: ProverNetwork,
+                    > tonic::server::UnaryService<
+                        super::super::types::GetProverRequirementsRequest,
+                    > for GetProverRequirementsSvc<T> {
+                        type Response = super::super::types::GetProverRequirementsResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<
+                                super::super::types::GetProverRequirementsRequest,
+                            >,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as ProverNetwork>::get_prover_requirements(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetProverRequirementsSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/network.ProverNetwork/GetProverStatus" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetProverStatusSvc<T: ProverNetwork>(pub Arc<T>);
+                    impl<
+                        T: ProverNetwork,
+                    > tonic::server::UnaryService<
+                        super::super::types::GetProverStatusRequest,
+                    > for GetProverStatusSvc<T> {
+                        type Response = super::super::types::GetProverStatusResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<
+                                super::super::types::GetProverStatusRequest,
+                            >,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as ProverNetwork>::get_prover_status(&inner, request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetProverStatusSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/crates/types/network/src/network.rs
+++ b/crates/types/network/src/network.rs
@@ -1221,8 +1221,8 @@ pub mod prover_network_client {
         }
         /// Get the network's prover performance requirements. A fulfilled request counts
         /// toward a prover's success rate only if fulfilled within
-        /// `GREATEST(gas / min_mgas_per_second, floor_latency_seconds)` seconds of request
-        /// creation.
+        /// `GREATEST(gas_used / 1_000_000 / min_mgas_per_second, floor_latency_seconds)`
+        /// seconds of request creation.
         pub async fn get_prover_requirements(
             &mut self,
             request: impl tonic::IntoRequest<
@@ -2188,8 +2188,8 @@ pub mod prover_network_server {
         >;
         /// Get the network's prover performance requirements. A fulfilled request counts
         /// toward a prover's success rate only if fulfilled within
-        /// `GREATEST(gas / min_mgas_per_second, floor_latency_seconds)` seconds of request
-        /// creation.
+        /// `GREATEST(gas_used / 1_000_000 / min_mgas_per_second, floor_latency_seconds)`
+        /// seconds of request creation.
         async fn get_prover_requirements(
             &self,
             request: tonic::Request<super::super::types::GetProverRequirementsRequest>,

--- a/crates/types/network/src/types.rs
+++ b/crates/types/network/src/types.rs
@@ -1715,6 +1715,59 @@ pub struct Bid {
     pub amount: ::prost::alloc::string::String,
 }
 #[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct GetProverRequirementsRequest {}
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ProverRequirements {
+    /// Whole-request proving rate in MGas/s: gas_used divided by fulfillment latency
+    /// must meet this whenever the rate grants more time than the floor.
+    #[prost(string, tag = "1")]
+    pub min_mgas_per_second: ::prost::alloc::string::String,
+    /// Minimum time budget in seconds granted to every request regardless of size.
+    #[prost(uint64, tag = "2")]
+    pub floor_latency_seconds: u64,
+    /// Minimum success rate over resolved requests in the lookback window; falling
+    /// below it means suspension.
+    #[prost(string, tag = "3")]
+    pub min_success_rate_percentage: ::prost::alloc::string::String,
+    /// Performance evaluation lookback window in hours.
+    #[prost(uint64, tag = "4")]
+    pub performance_lookback_hours: u64,
+    /// Minimum resolved (succeeded or failed) requests in the window for an
+    /// evaluation to run at all.
+    #[prost(uint64, tag = "5")]
+    pub min_resolved_requests_to_evaluate: u64,
+}
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetProverRequirementsResponse {
+    /// The enforced requirements. Absent when performance requirements are not
+    /// enforced on this network.
+    #[prost(message, optional, tag = "1")]
+    pub requirements: ::core::option::Option<ProverRequirements>,
+}
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetProverStatusRequest {
+    /// The address of the prover.
+    #[prost(bytes = "vec", tag = "1")]
+    pub prover: ::prost::alloc::vec::Vec<u8>,
+}
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct GetProverStatusResponse {
+    /// Whether the prover is whitelisted.
+    #[prost(bool, tag = "1")]
+    pub is_whitelisted: bool,
+    /// Whether the prover is exempt from performance evaluation (high availability).
+    #[prost(bool, tag = "2")]
+    pub is_high_availability: bool,
+    /// Unix seconds when the current suspension expires; absent when not suspended.
+    #[prost(uint64, optional, tag = "3")]
+    pub suspended_until: ::core::option::Option<u64>,
+}
+#[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetProverStatsRequest {
     #[prost(bytes = "vec", optional, tag = "1")]

--- a/proto/network.proto
+++ b/proto/network.proto
@@ -149,8 +149,8 @@ service ProverNetwork {
       returns (types.SuspendProverResponse) {}
   // Get the network's prover performance requirements. A fulfilled request counts
   // toward a prover's success rate only if fulfilled within
-  // `GREATEST(gas / min_mgas_per_second, floor_latency_seconds)` seconds of request
-  // creation.
+  // `GREATEST(gas_used / 1_000_000 / min_mgas_per_second, floor_latency_seconds)`
+  // seconds of request creation.
   rpc GetProverRequirements(types.GetProverRequirementsRequest)
       returns (types.GetProverRequirementsResponse) {}
   // Get a prover's whitelist and suspension status.

--- a/proto/network.proto
+++ b/proto/network.proto
@@ -147,6 +147,15 @@ service ProverNetwork {
   // Suspend a prover.
   rpc SuspendProver(types.SuspendProverRequest)
       returns (types.SuspendProverResponse) {}
+  // Get the network's prover performance requirements. A fulfilled request counts
+  // toward a prover's success rate only if fulfilled within
+  // `GREATEST(gas / min_mgas_per_second, floor_latency_seconds)` seconds of request
+  // creation.
+  rpc GetProverRequirements(types.GetProverRequirementsRequest)
+      returns (types.GetProverRequirementsResponse) {}
+  // Get a prover's whitelist and suspension status.
+  rpc GetProverStatus(types.GetProverStatusRequest)
+      returns (types.GetProverStatusResponse) {}
   // Report the self-reported build identity of a prover's cluster components (fulfiller,
   // coordinator, workers). Debugging telemetry signed by the prover key; not attestation.
   rpc ReportProverInfo(types.ReportProverInfoRequest) returns (types.ReportProverInfoResponse) {}

--- a/proto/types.proto
+++ b/proto/types.proto
@@ -1303,6 +1303,45 @@ message Bid {
  *** Provers ***
  ***************/
 
+message GetProverRequirementsRequest {}
+
+message ProverRequirements {
+  // Whole-request proving rate in MGas/s: gas_used divided by fulfillment latency
+  // must meet this whenever the rate grants more time than the floor.
+  string min_mgas_per_second = 1;
+  // Minimum time budget in seconds granted to every request regardless of size.
+  uint64 floor_latency_seconds = 2;
+  // Minimum success rate over resolved requests in the lookback window; falling
+  // below it means suspension.
+  string min_success_rate_percentage = 3;
+  // Performance evaluation lookback window in hours.
+  uint64 performance_lookback_hours = 4;
+  // Minimum resolved (succeeded or failed) requests in the window for an
+  // evaluation to run at all.
+  uint64 min_resolved_requests_to_evaluate = 5;
+}
+
+message GetProverRequirementsResponse {
+  // The enforced requirements. Absent when performance requirements are not
+  // enforced on this network.
+  ProverRequirements requirements = 1;
+}
+
+message GetProverStatusRequest {
+  // The address of the prover.
+  bytes prover = 1;
+}
+
+message GetProverStatusResponse {
+  // Whether the prover is whitelisted.
+  bool is_whitelisted = 1;
+  // Whether the prover is exempt from performance evaluation (high availability).
+  bool is_high_availability = 2;
+  // Unix seconds when the current suspension expires; absent when not suspended.
+  optional uint64 suspended_until = 3;
+}
+
+
 message GetProverStatsRequest {
   optional bytes address = 1;
 }


### PR DESCRIPTION
The network enforces a performance bar on provers (latency budget + success rate), but there's no machine-readable way to get it — so bidder software can't factor the bar into its decisions and happily bids on requests it can't fulfill within the required budget. This adds the read-only contract to close that loop:

- **GetProverRequirements** — the enforced budget (`GREATEST(gas / min_mgas_per_second, floor_latency_seconds)`) plus the suspension policy around it.
- **GetProverStatus** — whitelist/HA flags and suspended_until (present only while a suspension is live), so a bidder can also react to its own suspension programmatically.

Server side lands in network-services. First consumer is the sp1-cluster bidder: it polls both, clamps its bid deadlines to the published bar, and pauses bidding with a clear error while suspended. The contract lives here because sp1-cluster pulls spn-network-types from this repo.