### PR TITLE
feat: add gas estimates rpc and spn-bidding crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7481,6 +7481,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "spn-bidding"
+version = "0.1.0"
+
+[[package]]
 name = "spn-calibrator"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["cryptography"]
 members = [
     "bin/node",
     "crates/network/artifacts",
+    "crates/network/bidding",
     "crates/network/pricing",
     "crates/network/rpc",
     "crates/network/utils",

--- a/crates/network/bidding/Cargo.toml
+++ b/crates/network/bidding/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "spn-bidding"
+description = "Pure bidding policy shared by SPN bidders: gas-aware admission, performance-requirement deadlines, and expected-gas sizing from published program estimates."
+version = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+keywords = { workspace = true }
+categories = { workspace = true }
+
+[dependencies]

--- a/crates/network/bidding/src/admission.rs
+++ b/crates/network/bidding/src/admission.rs
@@ -1,0 +1,267 @@
+//! Gas-aware admission: conservative schedulability against the request's effective
+//! deadline, plus a controller-slot capacity cap.
+
+/// The cluster's capacity and current in-flight load. Set up once per bid pass; the
+/// load fields (`active_proofs`, `active_wraps`, `committed_gas`) accumulate as
+/// requests are admitted within the pass.
+pub struct ClusterState {
+    // Capacity.
+    /// Total cluster throughput in million gas per second.
+    pub throughput_mgas: f64,
+    /// Per-node CPU-worker capacities in task-weight units (GB of RAM), the same
+    /// measure workers declare to the coordinator. A wrap stage must fit within a
+    /// single node, so per-node granularity is what bounds concurrent wraps.
+    pub cpu_worker_max_weights: Vec<u32>,
+    // In-flight load.
+    /// Proofs currently in flight.
+    pub active_proofs: u32,
+    /// In-flight proofs whose mode requires a wrap stage (Groth16/Plonk).
+    pub active_wraps: u32,
+    /// Sum of expected gas of in-flight proofs (gas units).
+    pub committed_gas: u64,
+}
+
+impl ClusterState {
+    /// Concurrent proofs the fleet can hold: each active proof keeps a weight-1
+    /// controller task resident on a CPU worker for its whole lifetime, so total
+    /// CPU-worker weight bounds proof count.
+    fn controller_slots(&self) -> u32 {
+        self.cpu_worker_max_weights.iter().fold(0u32, |acc, w| acc.saturating_add(*w))
+    }
+
+    /// No controller slot free for another proof.
+    fn at_capacity(&self) -> bool {
+        self.active_proofs >= self.controller_slots()
+    }
+
+    /// Seconds to prove `gas` at the cluster's throughput.
+    fn drain_secs(&self, gas: u64) -> f64 {
+        (gas as f64 / 1_000_000.0) / self.throughput_mgas
+    }
+
+    /// Wraps the fleet can run concurrently at `wrap_weight`. A wrap must fit
+    /// within one node, so slots are summed per node rather than derived from the
+    /// fleet total. At least 1, so an oversized wrap serializes instead of
+    /// dividing by zero.
+    fn wrap_slots(&self, wrap_weight: u32) -> u32 {
+        self.cpu_worker_max_weights
+            .iter()
+            .map(|node_weight| node_weight / wrap_weight)
+            .sum::<u32>()
+            .max(1)
+    }
+
+    /// Seconds the request queues behind in-flight wraps: full cycles of waiting
+    /// at the fleet's slot capacity. Zero for modes without a wrap stage.
+    fn wrap_queue_secs(&self, req: &RequestDemand) -> f64 {
+        if req.wrap_weight == 0 {
+            return 0.0;
+        }
+        (self.active_wraps / self.wrap_slots(req.wrap_weight)) as f64 * req.wrap_secs
+    }
+}
+
+/// One request's demand on the cluster.
+pub struct RequestDemand {
+    /// Expected gas of the request (gas units).
+    pub expected_gas: u64,
+    /// Seconds until the request's effective deadline.
+    pub deadline_secs: u64,
+    /// Base safety buffer in seconds, excluding the wrap stage.
+    pub buffer_secs: f64,
+    /// Duration of this request's wrap stage in seconds; 0 for modes without one.
+    /// Counted once for the request's own wrap and once per queued cycle behind
+    /// in-flight wraps.
+    pub wrap_secs: f64,
+    /// Task weight of this request's wrap stage (GB of RAM); 0 for modes without
+    /// one. Each CPU node runs `node_weight / wrap_weight` wraps per cycle, and this
+    /// request queues behind the in-flight wraps at the fleet's combined rate.
+    pub wrap_weight: u32,
+}
+
+impl RequestDemand {
+    /// Fixed cost on top of proving time: the base buffer plus the request's own
+    /// wrap stage.
+    fn overhead_secs(&self) -> f64 {
+        self.buffer_secs + self.wrap_secs
+    }
+
+    /// Whether an estimated completion time meets the request's deadline.
+    fn fits(&self, completion_secs: f64) -> bool {
+        completion_secs <= self.deadline_secs as f64
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum AdmissionOutcome {
+    /// Fits under conservative load (serial drain of committed gas).
+    AdmitLoaded,
+    /// No controller slot free — active proofs already occupy the fleet's
+    /// CPU-worker weight.
+    RejectCap,
+    /// Can't fit the deadline even with the whole cluster — never bid.
+    RejectInfeasible,
+    /// Fails the loaded check — completing behind the committed queue would miss the
+    /// deadline.
+    RejectLoad,
+}
+
+impl AdmissionOutcome {
+    pub fn admits(self) -> bool {
+        matches!(self, Self::AdmitLoaded)
+    }
+}
+
+/// Gas-aware admission policy.
+///
+/// - Reject when no controller slot is free (proof count is bounded by CPU-worker weight).
+/// - Reject requests that can't fit their deadline even on an empty cluster (bidding on those means
+///   a deadline miss).
+/// - Admit only when the request fits under the conservative loaded model: all committed gas drains
+///   serially first, and a wrap-mode request queues behind the in-flight wraps at the rate its
+///   weight allows. Bidding on work that fails this check would risk missing the network's
+///   performance deadline and a resulting suspension.
+pub fn admission_outcome(cluster: &ClusterState, req: &RequestDemand) -> AdmissionOutcome {
+    if cluster.at_capacity() {
+        return AdmissionOutcome::RejectCap;
+    }
+    let solo = cluster.drain_secs(req.expected_gas) + req.overhead_secs();
+    if !req.fits(solo) {
+        return AdmissionOutcome::RejectInfeasible;
+    }
+    let loaded = cluster.drain_secs(cluster.committed_gas.saturating_add(req.expected_gas))
+        + req.overhead_secs()
+        + cluster.wrap_queue_secs(req);
+    if req.fits(loaded) {
+        AdmissionOutcome::AdmitLoaded
+    } else {
+        AdmissionOutcome::RejectLoad
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Baseline: 100 Mgas/s cluster, one 96-weight CPU node, empty load. Each test
+    /// overrides the dimension under test.
+    fn cluster() -> ClusterState {
+        ClusterState {
+            throughput_mgas: 100.0,
+            cpu_worker_max_weights: vec![96],
+            active_proofs: 0,
+            active_wraps: 0,
+            committed_gas: 0,
+        }
+    }
+
+    /// Baseline request: 1 Bgas (→ 10s solo at 100 Mgas/s), roomy deadline, 30s buffer.
+    fn request() -> RequestDemand {
+        RequestDemand {
+            expected_gas: 1_000_000_000,
+            deadline_secs: 100,
+            buffer_secs: 30.0,
+            wrap_secs: 0.0,
+            wrap_weight: 0,
+        }
+    }
+
+    /// Empty cluster, fits deadline → admit (loaded tier).
+    #[test]
+    fn admits_when_loaded_fits() {
+        assert_eq!(admission_outcome(&cluster(), &request()), AdmissionOutcome::AdmitLoaded);
+    }
+
+    /// Controller capacity (Σ CPU-worker weights) still rejects regardless of gas
+    /// math: 96 active proofs fill the 96-weight node.
+    #[test]
+    fn rejects_at_cap() {
+        let c = ClusterState { active_proofs: 96, ..cluster() };
+        assert_eq!(admission_outcome(&c, &request()), AdmissionOutcome::RejectCap);
+    }
+
+    /// Controller slots sum across nodes: two 96-weight nodes hold 192 proofs, so
+    /// 100 active still admits and 192 rejects.
+    #[test]
+    fn cap_sums_across_nodes() {
+        let c =
+            ClusterState { active_proofs: 100, cpu_worker_max_weights: vec![96, 96], ..cluster() };
+        assert_eq!(admission_outcome(&c, &request()), AdmissionOutcome::AdmitLoaded);
+        let c =
+            ClusterState { active_proofs: 192, cpu_worker_max_weights: vec![96, 96], ..cluster() };
+        assert_eq!(admission_outcome(&c, &request()), AdmissionOutcome::RejectCap);
+    }
+
+    /// Solo time (10s + 30s buffer) over a 35s deadline → infeasible, never bid.
+    #[test]
+    fn rejects_solo_infeasible() {
+        let r = RequestDemand { deadline_secs: 35, ..request() };
+        assert_eq!(admission_outcome(&cluster(), &r), AdmissionOutcome::RejectInfeasible);
+    }
+
+    /// Wrap queueing binds before gas throughput for heavy wrap modes: a 60-weight
+    /// wrap runs alone on a 96-weight fleet, so each in-flight wrap adds one wrap
+    /// cycle to the completion time.
+    #[test]
+    fn wrap_queue_limits_wrap_modes() {
+        // 10s gas + 60s buffer + 80s own wrap + n × 80s queue ≤ 420s holds through
+        // n = 3, so the fourth concurrent wrap is the last admitted.
+        let r = RequestDemand {
+            deadline_secs: 420,
+            buffer_secs: 60.0,
+            wrap_secs: 80.0,
+            wrap_weight: 60,
+            ..request()
+        };
+        let c = ClusterState { active_wraps: 3, ..cluster() };
+        assert_eq!(admission_outcome(&c, &r), AdmissionOutcome::AdmitLoaded);
+        let c = ClusterState { active_wraps: 4, ..cluster() };
+        assert_eq!(admission_outcome(&c, &r), AdmissionOutcome::RejectLoad);
+        // Modes without a wrap stage are unaffected by in-flight wraps.
+        let c = ClusterState { active_wraps: 4, ..cluster() };
+        assert_eq!(admission_outcome(&c, &request()), AdmissionOutcome::AdmitLoaded);
+    }
+
+    /// Lighter wraps pack more per cycle and more CPU-worker weight drains the queue
+    /// faster; a wrap heavier than the fleet still gets one slot rather than
+    /// dividing by zero.
+    #[test]
+    fn wrap_capacity_scales_with_weight() {
+        // A 14-weight wrap packs 96 / 14 = 6 per cycle: 4 in-flight wraps queue for
+        // zero cycles, so the request fits where a 60-weight wrap would not.
+        let light = RequestDemand {
+            deadline_secs: 420,
+            buffer_secs: 60.0,
+            wrap_secs: 80.0,
+            wrap_weight: 14,
+            ..request()
+        };
+        let c = ClusterState { active_wraps: 4, ..cluster() };
+        assert_eq!(admission_outcome(&c, &light), AdmissionOutcome::AdmitLoaded);
+        // A second node adds a second slot for a heavy wrap: floor(4 / 2) = 2
+        // cycles fits the same budget.
+        let heavy = RequestDemand { wrap_weight: 60, ..light };
+        let c = ClusterState { active_wraps: 4, cpu_worker_max_weights: vec![96, 96], ..cluster() };
+        assert_eq!(admission_outcome(&c, &heavy), AdmissionOutcome::AdmitLoaded);
+        // Slots are per node, not fleet-total: two 96-weight nodes hold two 60-weight
+        // wraps (4 queue cycles at 8 in flight), while one 192-weight node holds
+        // three (2 cycles).
+        let c = ClusterState { active_wraps: 8, cpu_worker_max_weights: vec![96, 96], ..cluster() };
+        assert_eq!(admission_outcome(&c, &heavy), AdmissionOutcome::RejectLoad);
+        let c = ClusterState { active_wraps: 8, cpu_worker_max_weights: vec![192], ..cluster() };
+        assert_eq!(admission_outcome(&c, &heavy), AdmissionOutcome::AdmitLoaded);
+        // A wrap heavier than the whole fleet serializes fully.
+        let oversized = RequestDemand { wrap_weight: 200, ..light };
+        let c = ClusterState { active_wraps: 4, ..cluster() };
+        assert_eq!(admission_outcome(&c, &oversized), AdmissionOutcome::RejectLoad);
+    }
+
+    /// Committed load pushes completion past the deadline, though the request is
+    /// solo-feasible → reject.
+    #[test]
+    fn rejects_on_load() {
+        // loaded = (9 + 1) Bgas / 100 Mgas/s + 30 = 130s > 100s; solo = 40s ≤ 100s.
+        let c = ClusterState { committed_gas: 9_000_000_000, ..cluster() };
+        assert_eq!(admission_outcome(&c, &request()), AdmissionOutcome::RejectLoad);
+    }
+}

--- a/crates/network/bidding/src/estimate_cache.rs
+++ b/crates/network/bidding/src/estimate_cache.rs
@@ -1,0 +1,120 @@
+//! Client-side TTL cache for published program gas estimates.
+//!
+//! Entries cache the *resolution*: a program the network reports no history for caches
+//! as absent, so unknown programs are not re-fetched every bid pass. Callers pass
+//! `now` explicitly, keeping the type pure and its TTL behavior directly testable.
+
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
+
+/// How long a cached resolution serves before the network is consulted again. The
+/// published estimate changes slowly relative to the bid loop, so a long interval
+/// loses no useful freshness while sparing the network repeated lookups. Deliberately
+/// a constant, not a knob.
+pub const ESTIMATE_TTL: Duration = Duration::from_secs(300);
+
+/// Upper bound on cached programs.
+const MAX_ENTRIES: usize = 4096;
+
+struct Entry {
+    /// `Some` = published estimate; `None` = known absent (no fulfilled history).
+    estimate: Option<u64>,
+    fetched_at: Instant,
+}
+
+/// Result of a cache lookup: three states, because "never asked" and "asked, the
+/// network reported no history" must stay distinguishable — collapsing them would
+/// refetch known-absent programs on every pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EstimateLookup {
+    /// No fresh entry — ask the network.
+    Miss,
+    /// Fresh entry: the network reported no fulfilled history for this program.
+    KnownAbsent,
+    /// Fresh entry with a published estimate.
+    Hit(u64),
+}
+
+/// TTL map `vk_hash → resolution`, bounded by [`MAX_ENTRIES`].
+#[derive(Default)]
+pub struct EstimateCache {
+    entries: HashMap<Vec<u8>, Entry>,
+}
+
+impl EstimateCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Fresh resolution for `vk_hash`; see [`EstimateLookup`] for the three states.
+    pub fn lookup(&self, vk_hash: &[u8], now: Instant) -> EstimateLookup {
+        match self.entries.get(vk_hash) {
+            Some(entry) if now.duration_since(entry.fetched_at) < ESTIMATE_TTL => {
+                match entry.estimate {
+                    Some(estimate) => EstimateLookup::Hit(estimate),
+                    None => EstimateLookup::KnownAbsent,
+                }
+            }
+            _ => EstimateLookup::Miss,
+        }
+    }
+
+    /// Store a freshly fetched resolution. Expired entries are evicted when at
+    /// capacity; anything that still doesn't fit is not cached (the cache is an
+    /// optimization, never a gate).
+    pub fn store(&mut self, vk_hash: Vec<u8>, estimate: Option<u64>, now: Instant) {
+        if self.entries.len() >= MAX_ENTRIES && !self.entries.contains_key(&vk_hash) {
+            self.entries.retain(|_, e| now.duration_since(e.fetched_at) < ESTIMATE_TTL);
+            if self.entries.len() >= MAX_ENTRIES {
+                return;
+            }
+        }
+        self.entries.insert(vk_hash, Entry { estimate, fetched_at: now });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Fresh entries serve; expired entries read as uncached.
+    #[test]
+    fn ttl_expiry() {
+        let mut cache = EstimateCache::new();
+        let t0 = Instant::now();
+        cache.store(vec![1], Some(100), t0);
+        assert_eq!(cache.lookup(&[1], t0), EstimateLookup::Hit(100));
+        assert_eq!(cache.lookup(&[1], t0 + ESTIMATE_TTL), EstimateLookup::Miss);
+    }
+
+    /// Known-absent programs cache as a resolved absence, avoiding a refetch.
+    #[test]
+    fn negative_caching() {
+        let mut cache = EstimateCache::new();
+        let t0 = Instant::now();
+        cache.store(vec![2], None, t0);
+        assert_eq!(cache.lookup(&[2], t0), EstimateLookup::KnownAbsent);
+    }
+
+    /// At capacity with all entries fresh, new vks are simply not cached.
+    #[test]
+    fn full_cache_never_gates() {
+        let mut cache = EstimateCache::new();
+        let t0 = Instant::now();
+        for i in 0..MAX_ENTRIES as u16 {
+            cache.store(i.to_be_bytes().to_vec(), Some(1), t0);
+        }
+        cache.store(vec![0xFF; 3], Some(2), t0);
+        assert_eq!(
+            cache.lookup(&[0xFF; 3], t0),
+            EstimateLookup::Miss,
+            "not cached, caller still serves it"
+        );
+        // Once the old entries expire, new vks cache again.
+        let later = t0 + ESTIMATE_TTL;
+        cache.store(vec![0xFF; 3], Some(2), later);
+        assert_eq!(cache.lookup(&[0xFF; 3], later), EstimateLookup::Hit(2));
+    }
+}

--- a/crates/network/bidding/src/lib.rs
+++ b/crates/network/bidding/src/lib.rs
@@ -1,0 +1,16 @@
+//! Pure bidding policy shared by SPN bidders.
+//!
+//! Everything here is plain data and math — no proto types, no I/O — so the
+//! sp1-cluster bidder and the network-services bidder consume one implementation and
+//! one test suite. Each bidder keeps a thin adapter from its own generated proto
+//! types to these inputs.
+
+pub mod admission;
+pub mod estimate_cache;
+pub mod policy;
+pub mod requirements;
+
+pub use admission::{admission_outcome, AdmissionOutcome, ClusterState, RequestDemand};
+pub use estimate_cache::{EstimateCache, EstimateLookup};
+pub use policy::expected_gas;
+pub use requirements::{perf_deadline, PerformanceRequirements};

--- a/crates/network/bidding/src/policy.rs
+++ b/crates/network/bidding/src/policy.rs
@@ -1,0 +1,65 @@
+//! Expected-gas policy: reconcile the network-published estimate with a request's own
+//! limits into the single value used by admission. The estimation method is
+//! server-side and not modeled here.
+
+/// Expected gas for a request: the published estimate scaled by `estimate_multiplier`,
+/// capped by the request's own budget; the budget alone when the program has no
+/// published history. The `min` with the budget keeps a small per-request limit
+/// authoritative even when the program's history is larger.
+///
+/// `estimate_multiplier` is normally 1.0; operators raise it to size estimates more
+/// conservatively, or lower it when estimates consistently exceed observed usage.
+/// Callers validate it finite and positive at startup.
+pub fn expected_gas(
+    estimate: Option<u64>,
+    gas_limit: u64,
+    cycle_limit: u64,
+    estimate_multiplier: f64,
+) -> u64 {
+    // gas_limit == 0 means the cycle limit governs execution (proto contract). Fall
+    // back to it so an unsized request is not treated as zero-cost and admitted
+    // freely; cycle count is close to gas in magnitude and serves as a budget.
+    let limit = if gas_limit > 0 { gas_limit } else { cycle_limit };
+    // A non-positive estimate carries no information; treat it as absent rather than
+    // letting the request through admission at zero cost.
+    let estimate = estimate.filter(|&e| e > 0);
+    match estimate {
+        Some(e) => ((e as f64 * estimate_multiplier) as u64).min(limit),
+        None => limit,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// No estimate → the request's own budget; gas_limit=0 → cycle_limit governs.
+    /// The multiplier never applies to the limit fallback.
+    #[test]
+    fn no_estimate_falls_back_to_limits() {
+        assert_eq!(expected_gas(None, 5_000, 9_000, 2.0), 5_000);
+        assert_eq!(expected_gas(None, 0, 9_000, 2.0), 9_000);
+    }
+
+    /// A published estimate of 0 is treated as absent, not as a free request.
+    #[test]
+    fn zero_estimate_treated_as_absent() {
+        assert_eq!(expected_gas(Some(0), 5_000, 0, 1.0), 5_000);
+    }
+
+    /// Estimates are capped by an honest per-request budget but never inflated by it.
+    #[test]
+    fn min_with_limit() {
+        assert_eq!(expected_gas(Some(10_000), 5_000, 0, 1.0), 5_000);
+        assert_eq!(expected_gas(Some(3_000), 5_000, 0, 1.0), 3_000);
+        assert_eq!(expected_gas(Some(3_000), 0, 2_000, 1.0), 2_000);
+    }
+
+    /// The multiplier scales the estimate before the budget cap, in both directions.
+    #[test]
+    fn multiplier_scales_estimate() {
+        assert_eq!(expected_gas(Some(3_000), 100_000, 0, 1.5), 4_500);
+        assert_eq!(expected_gas(Some(3_000), 100_000, 0, 0.5), 1_500);
+        assert_eq!(expected_gas(Some(3_000), 4_000, 0, 2.0), 4_000, "cap still wins");
+    }
+}

--- a/crates/network/bidding/src/requirements.rs
+++ b/crates/network/bidding/src/requirements.rs
@@ -1,0 +1,82 @@
+//! The network's published prover performance requirements, as bidding inputs.
+//!
+//! A fulfilled request counts toward the prover's success rate only if fulfilled
+//! within `perf_deadline` of its creation; falling below the success-rate bar leads
+//! to suspension. Proto-free: each bidder adapts its generated response type via
+//! [`PerformanceRequirements::from_parts`].
+
+/// The performance budget parameters: `budget = max(floor, gas / rate)`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PerformanceRequirements {
+    /// Whole-request proving rate in MGas/s required whenever it grants more time
+    /// than the floor.
+    pub min_mgas_per_second: f64,
+    /// Minimum time budget in seconds granted to every request.
+    pub floor_latency_seconds: u64,
+}
+
+impl PerformanceRequirements {
+    /// Build from wire primitives. Returns `None` when the rate doesn't parse to a
+    /// finite positive number — degrading to unclamped bidding, same as when the
+    /// network publishes no requirements at all.
+    pub fn from_parts(min_mgas_per_second: &str, floor_latency_seconds: u64) -> Option<Self> {
+        let min_mgas_per_second: f64 = min_mgas_per_second.parse().ok()?;
+        if !min_mgas_per_second.is_finite() || min_mgas_per_second <= 0.0 {
+            return None;
+        }
+        Some(Self { min_mgas_per_second, floor_latency_seconds })
+    }
+}
+
+/// Absolute unix deadline by which a request of `expected_gas` must be fulfilled to
+/// count as successful under the network's performance requirements: the budget is
+/// `max(floor, gas / rate)`.
+///
+/// The network judges on actual `gas_used`, which is unknown before execution;
+/// `expected_gas` is an estimate. When the rate term governs, an overestimate yields a
+/// looser budget than the network will apply. This is tolerated: admission sizes
+/// completion time from the same `expected_gas`, so both estimates move together, and
+/// the rate term binds only when the effective pace falls below the published rate.
+pub fn perf_deadline(created_at: u64, expected_gas: u64, req: &PerformanceRequirements) -> u64 {
+    let rate_secs = (expected_gas as f64 / (req.min_mgas_per_second * 1e6)) as u64;
+    created_at.saturating_add(rate_secs.max(req.floor_latency_seconds))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn requirements() -> PerformanceRequirements {
+        PerformanceRequirements { min_mgas_per_second: 24.0, floor_latency_seconds: 420 }
+    }
+
+    #[test]
+    fn parses_valid_parts() {
+        assert_eq!(PerformanceRequirements::from_parts("24", 420), Some(requirements()));
+    }
+
+    #[test]
+    fn invalid_rate_parses_to_none() {
+        for rate in ["", "abc", "0", "-24", "NaN", "inf"] {
+            assert_eq!(PerformanceRequirements::from_parts(rate, 420), None, "rate {rate}");
+        }
+    }
+
+    /// The rate would grant 0s and ~42s respectively; the 420s floor governs.
+    #[test]
+    fn small_gas_gets_floor_budget() {
+        assert_eq!(perf_deadline(1_000, 0, &requirements()), 1_420);
+        assert_eq!(perf_deadline(1_000, 1_000_000_000, &requirements()), 1_420);
+    }
+
+    /// 14.4B gas / 24 MGas/s = 600s, above the 420s floor.
+    #[test]
+    fn large_gas_gets_rate_budget() {
+        assert_eq!(perf_deadline(1_000, 14_400_000_000, &requirements()), 1_000 + 600);
+    }
+
+    #[test]
+    fn saturates_instead_of_overflowing() {
+        assert_eq!(perf_deadline(u64::MAX, u64::MAX, &requirements()), u64::MAX);
+    }
+}

--- a/crates/types/network/src/network.rs
+++ b/crates/types/network/src/network.rs
@@ -1276,6 +1276,36 @@ pub mod prover_network_client {
                 .insert(GrpcMethod::new("network.ProverNetwork", "GetProverStatus"));
             self.inner.unary(req, path, codec).await
         }
+        /// Get the network's per-program gas estimates, so provers can size a request by
+        /// its expected gas instead of its declared limits.
+        pub async fn get_program_gas_estimates(
+            &mut self,
+            request: impl tonic::IntoRequest<
+                super::super::types::GetProgramGasEstimatesRequest,
+            >,
+        ) -> std::result::Result<
+            tonic::Response<super::super::types::GetProgramGasEstimatesResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/network.ProverNetwork/GetProgramGasEstimates",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("network.ProverNetwork", "GetProgramGasEstimates"),
+                );
+            self.inner.unary(req, path, codec).await
+        }
         /// Report the self-reported build identity of a prover's cluster components (fulfiller,
         /// coordinator, workers). Debugging telemetry signed by the prover key; not attestation.
         pub async fn report_prover_info(
@@ -2203,6 +2233,15 @@ pub mod prover_network_server {
             request: tonic::Request<super::super::types::GetProverStatusRequest>,
         ) -> std::result::Result<
             tonic::Response<super::super::types::GetProverStatusResponse>,
+            tonic::Status,
+        >;
+        /// Get the network's per-program gas estimates, so provers can size a request by
+        /// its expected gas instead of its declared limits.
+        async fn get_program_gas_estimates(
+            &self,
+            request: tonic::Request<super::super::types::GetProgramGasEstimatesRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::super::types::GetProgramGasEstimatesResponse>,
             tonic::Status,
         >;
         /// Report the self-reported build identity of a prover's cluster components (fulfiller,
@@ -4601,6 +4640,58 @@ pub mod prover_network_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = GetProverStatusSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/network.ProverNetwork/GetProgramGasEstimates" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetProgramGasEstimatesSvc<T: ProverNetwork>(pub Arc<T>);
+                    impl<
+                        T: ProverNetwork,
+                    > tonic::server::UnaryService<
+                        super::super::types::GetProgramGasEstimatesRequest,
+                    > for GetProgramGasEstimatesSvc<T> {
+                        type Response = super::super::types::GetProgramGasEstimatesResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<
+                                super::super::types::GetProgramGasEstimatesRequest,
+                            >,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as ProverNetwork>::get_program_gas_estimates(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetProgramGasEstimatesSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/crates/types/network/src/types.rs
+++ b/crates/types/network/src/types.rs
@@ -1769,6 +1769,31 @@ pub struct GetProverStatusResponse {
 }
 #[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetProgramGasEstimatesRequest {
+    /// Programs to look up. The server caps the number per call.
+    #[prost(bytes = "vec", repeated, tag = "1")]
+    pub vk_hashes: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+}
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ProgramGasEstimate {
+    #[prost(bytes = "vec", tag = "1")]
+    pub vk_hash: ::prost::alloc::vec::Vec<u8>,
+    /// The network's expected gas for this program's next proof. The estimation method
+    /// is server-side and may change without notice.
+    #[prost(uint64, tag = "2")]
+    pub gas_estimate: u64,
+}
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetProgramGasEstimatesResponse {
+    /// One entry per requested vk the network has an estimate for; programs without
+    /// one are absent.
+    #[prost(message, repeated, tag = "1")]
+    pub estimates: ::prost::alloc::vec::Vec<ProgramGasEstimate>,
+}
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetProverStatsRequest {
     #[prost(bytes = "vec", optional, tag = "1")]
     pub address: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,

--- a/proto/network.proto
+++ b/proto/network.proto
@@ -156,6 +156,10 @@ service ProverNetwork {
   // Get a prover's whitelist and suspension status.
   rpc GetProverStatus(types.GetProverStatusRequest)
       returns (types.GetProverStatusResponse) {}
+  // Get the network's per-program gas estimates, so provers can size a request by
+  // its expected gas instead of its declared limits.
+  rpc GetProgramGasEstimates(types.GetProgramGasEstimatesRequest)
+      returns (types.GetProgramGasEstimatesResponse) {}
   // Report the self-reported build identity of a prover's cluster components (fulfiller,
   // coordinator, workers). Debugging telemetry signed by the prover key; not attestation.
   rpc ReportProverInfo(types.ReportProverInfoRequest) returns (types.ReportProverInfoResponse) {}

--- a/proto/types.proto
+++ b/proto/types.proto
@@ -1341,6 +1341,24 @@ message GetProverStatusResponse {
   optional uint64 suspended_until = 3;
 }
 
+message GetProgramGasEstimatesRequest {
+  // Programs to look up. The server caps the number per call.
+  repeated bytes vk_hashes = 1;
+}
+
+message ProgramGasEstimate {
+  bytes vk_hash = 1;
+  // The network's expected gas for this program's next proof. The estimation method
+  // is server-side and may change without notice.
+  uint64 gas_estimate = 2;
+}
+
+message GetProgramGasEstimatesResponse {
+  // One entry per requested vk the network has an estimate for; programs without
+  // one are absent.
+  repeated ProgramGasEstimate estimates = 1;
+}
+
 
 message GetProverStatsRequest {
   optional bytes address = 1;


### PR DESCRIPTION
## What

Two pieces that let bidders size proof requests by expected gas instead of declared limits:

**GetProgramGasEstimates** RPC. Batch lookup of per-program gas estimates, derived from fulfilled request history. The estimation method lives server-side and can change without touching this contract; programs with no history are simply absent from the response. Server caps the batch size per call.

**spn-bidding** crate. Pure, dependency-free bidding policy shared by consumer repos.

- gas-aware admission: solo-feasibility and loaded-schedulability checks against a request's effective deadline, including wrap-stage capacity packing
- expected-gas policy: published estimate scaled by an operator multiplier, capped by the request's own limits
- client-side TTL cache for estimate resolutions
- port the performance-requirement deadline math

## Why

Bidders previously admitted work on concurrency counts alone, so clusters over- or under-committed depending on the proof mix. Publishing estimates from the network and centralizing the policy math gives every prover the same admission foundation, with one home for the logic instead of per-bidder copies.